### PR TITLE
Add CSS and JS enabling click-to-toggle on heading

### DIFF
--- a/src/css/unison-doc.css
+++ b/src/css/unison-doc.css
@@ -303,6 +303,11 @@
   flex-direction: row;
 }
 
+.unison-doc .folded-summary,
+.unison-doc .folded-details > div .word {
+  cursor: pointer;
+}
+
 .unison-doc .folded.is-folded > .folded-content > .folded-details {
   display: none;
 }

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -24,7 +24,7 @@
   ].forEach((summary) => {
     summary.addEventListener("click", (ev) => {
       const folded = findUpByClass(ev.currentTarget, "folded");
-      folded.classList.toggle("is-folded");
+      folded?.classList?.toggle("is-folded");
     });
   });
 

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -24,7 +24,8 @@
   ].forEach((summary) => {
     summary.addEventListener("click", (ev) => {
       const folded = findUpByClass(ev.currentTarget, "folded");
-      folded?.classList?.toggle("is-folded");
+      if (!folded) { return; }
+      folded.classList.toggle("is-folded");
     });
   });
 

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -1,10 +1,29 @@
 (() => {
   const all = document.querySelectorAll.bind(document);
   const one = document.querySelector.bind(document);
+  const findUpByClass = (el, class_) => {
+    if (!el || !el.classList) {
+      return null;
+    }
+    if (el.classList.contains(class_)) {
+      return el;
+    }
+    return findUpByClass(el.parentNode, class_);
+  }
 
   [...all(".fold-toggle")].forEach((toggle) => {
     toggle.addEventListener("click", (ev) => {
       const folded = ev.currentTarget.parentNode;
+      folded.classList.toggle("is-folded");
+    });
+  });
+
+  [
+    ...all(".folded-summary"),
+    ...all(".folded-details > div .word"),
+  ].forEach((summary) => {
+    summary.addEventListener("click", (ev) => {
+      const folded = findUpByClass(ev.currentTarget, "folded");
       folded.classList.toggle("is-folded");
     });
   });

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -1,15 +1,6 @@
 (() => {
   const all = document.querySelectorAll.bind(document);
   const one = document.querySelector.bind(document);
-  const findUpByClass = (el, class_) => {
-    if (!el || !el.classList) {
-      return null;
-    }
-    if (el.classList.contains(class_)) {
-      return el;
-    }
-    return findUpByClass(el.parentNode, class_);
-  }
 
   [...all(".fold-toggle")].forEach((toggle) => {
     toggle.addEventListener("click", (ev) => {
@@ -23,7 +14,7 @@
     ...all(".folded-details > div .word"),
   ].forEach((summary) => {
     summary.addEventListener("click", (ev) => {
-      const folded = findUpByClass(ev.currentTarget, "folded");
+      const folded = ev.currentTarget.closest(".folded");
       if (!folded) { return; }
       folded.classList.toggle("is-folded");
     });


### PR DESCRIPTION
I was setting up a new computer and noticed this minor papercut on the Quickstart page: the heading on the toggle lists are not clickable. I saw in `#troubleshooting` that other people ran into this as well.

This was the most straightforward way I could find to fix it without having to change how `unison` generates the HTML. I don't love the `.folded-details > div .word` selector, but it does seem to work and not over-select in the light testing I did.

![quickstart-toggle](https://user-images.githubusercontent.com/166258/176539279-33b6ccaf-7126-4b90-9565-555518c30f6e.gif)

If this is not the way you'd prefer for this to be fixed, and you'd prefer the HTML generator to change instead, feel free to reject this PR, I will not be offended!