### PR TITLE
Support new Share URL scheme

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -496,7 +496,7 @@ function convertRefsToUnisonShareLinks(dom) {
         if (ref && refType) {
           let link = dom.window.document.createElement("a");
 
-          link.href = `${UNISON_SHARE_BASE_URL}/@unison/code/latest/namespaces/public/;/${refType}s/${ref}`;
+          link.href = `${UNISON_SHARE_BASE_URL}/@unison/p/code/latest/namespaces/public/;/${refType}s/${ref}`;
           link.target = "_blank";
           link.innerHTML = span.innerHTML;
           link.classList = span.classList;


### PR DESCRIPTION
URLs in Share has changed to have a `/p/` between the user handle and the the `/code` segments (looks like `.../@unison/p/code/...`). Update the website links accordingly.

---

@rlmark I don't know the impact on other links to Share that we might have as more regular links?