### PR TITLE
Adjust build script for new docs.to-html command

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -83,14 +83,14 @@ function build() {
     .then(() => mkdir("./src/docs"))
     .then(() =>
       copy(
-        "./build/docs/_sidebar.html",
+        "./build/learn/_sidebar.html",
         "./src/_includes/_docs-sidebar-content.njk"
       ).on(copy.events.COPY_FILE_COMPLETE, ({ src, dest }) => {
         transformdocsSidebar(src, dest, false);
       })
     )
     .then(() =>
-      copy("./build/docs", "./src/docs", {
+      copy("./build/learn", "./src/docs", {
         rename: kebabCase,
       }).on(copy.events.COPY_FILE_COMPLETE, ({ src, dest }) => {
         if (!isFragment(dest) && !isGlossary(dest)) {
@@ -116,7 +116,7 @@ function build() {
     .then(() => mkdir("./src/blog/posts"))
     .then(() => mkdir("./src/blog/posts/holiday-card-2023"))
     .then(() =>
-      copy("./build/blog", "./src/blog/posts", {
+      copy("./build/feed", "./src/blog/posts", {
         rename: kebabCase,
       }).on(copy.events.COPY_FILE_COMPLETE, ({ src, dest }) => {
         const fileName = path.basename(dest);

--- a/docs-to-html.md
+++ b/docs-to-html.md
@@ -2,8 +2,5 @@
 
 ```ucm
 .> switch @unison/website
-@unison/website/main> docs.to-html pages build/pages
-@unison/website/main> docs.to-html articles.distributedDatasets build/articles/distributedDatasets
-@unison/website/main> docs.to-html learn build/docs
-@unison/website/main> docs.to-html feed build/blog
+@unison/website/main> docs.to-html : build
 ```


### PR DESCRIPTION
There's a new `:` option for the `docs.to-html` command. Start using that and adjust the build script to do the renaming of learn and feed (to docs and blog respectively) instead of relying on the transcript to do that.