### PR TITLE
Updates docs-to-html command for use with 0.5.25

### DIFF
--- a/docs-to-html.md
+++ b/docs-to-html.md
@@ -1,6 +1,5 @@
 # Docs to HTML
 
 ```ucm
-.> switch @unison/website
-@unison/website/main> docs.to-html : build
+@unison/website/main> docs.to-html . build
 ```


### PR DESCRIPTION
If your Unison executable is 0.5.25 or greater, this is the version of the transcript that will work. New project-based-roots deprecate the `:` syntax. 