### PR TITLE
adds blog template so wrapped 2024 is included in blog index

### DIFF
--- a/src/wrapped2024.webc
+++ b/src/wrapped2024.webc
@@ -1,3 +1,19 @@
+---
+tags: blog
+permalink: wrapped2024/index.html
+authors:
+  - simon-højberg
+  - rebecca-mark
+categories:
+  - highlights
+date: 2025-01-29T00:00:00.000Z
+featuredImage: /assets/unison-wrapped-2024-social.png
+status: published
+summary: "We've had an unforgettable year of Unison features, contributions, and achievements. Take a look back at what we've accomplished and get a peek at what’s to come. 🔮"
+title: Unison's 2024 Wrapped
+eleventyExcludeFromCollections: false
+---
+
 <!DOCTYPE html>
 
 <html lang="en">

--- a/src/wrapped2024.webc
+++ b/src/wrapped2024.webc
@@ -10,7 +10,7 @@ date: 2025-01-29T00:00:00.000Z
 featuredImage: /assets/unison-wrapped-2024-social.png
 status: published
 summary: "We've had an unforgettable year of Unison features, contributions, and achievements. Take a look back at what we've accomplished and get a peek at what’s to come. 🔮"
-title: Unison's 2024 Wrapped
+title: Unison Wrapped 2024
 eleventyExcludeFromCollections: false
 ---
 


### PR DESCRIPTION
This captures the 2024 wrapped page in the blog page, similar to how we list the holiday card. 

Testing: 
This has been tested locally, with `npm start`, confirming that links from and to this post still work. 
