### PR TITLE
Update Unison Share links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ instance has a `_title` Unison `Doc` term that is transformed into the page as
 frontmatter for eleventy, where Docs has `_sidebar` term that makes up the
 index of the language documentation.
 
-Browse the Unison Docs that power the website here: https://share.unison-lang.org/@unison/p/code/latest/namespaces/public/website
+Browse the Unison Docs that power the website here: https://share.unison-lang.org/@unison/website/code/main/latest
 
-## Filing tickets and contributing to the Docs 
+## Filing tickets and contributing to the Docs
 
-Tickets about the website content should be filed [using the Unison Share ticketing feature](https://share.unison-lang.org/@unison/website/tickets). PR's are gratefully accepted through the regular [Unison code contribution workflow](https://share.unison-lang.org/@unison/website/code/main/latest/terms/learn/contributeDocs). 
+Tickets about the website content should be filed [using the Unison Share ticketing feature](https://share.unison-lang.org/@unison/website/tickets).
+PR's are gratefully accepted through the regular [Unison code contribution workflow](https://share.unison-lang.org/@unison/website/code/main/latest/terms/docs/contributeDocs).
 
 ## Setup for running locally and deployment
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ PR's are gratefully accepted through the regular [Unison code contribution workf
 Ensure all dependencies are installed by running `npm install` (node v17+
 recommended).
 
+Run `ucm --codebase-create .` and then `clone @unison/website` inside `ucm` to
+initialize the required Unison `Doc`.
+
 ## Running the website locally
 
 `npm start` will both build and start a local version of the website.


### PR DESCRIPTION
This PR fixes the Unison Share links pointing to what seems to be an outdated URL, returning the following page:

![image](https://github.com/user-attachments/assets/956839db-df61-4768-b7b1-54a2a1ac8f63)

I've also updated the local setup instructions to fix the `Error: ENOENT: no such file or directory, lstat './build/pages/home/_examples.html'` error I got when trying to run `npm start`.