### PR TITLE
Adding Unison for Python devs language guide

### DIFF
--- a/src/compare-lang/unison-for-python-devs.md
+++ b/src/compare-lang/unison-for-python-devs.md
@@ -1,7 +1,7 @@
 ---
 layout: "compare-lang"
 title: "Unison for Python devs"
-description: "Comparing syntax and patterns between Unison and Python"
+description: "Comparing syntax and patterns between Unison and Python 3"
 ---
 
 [[toc]]
@@ -26,6 +26,14 @@ aBoolean = true || false
 ```
 
 Unison terms can be defined at the top level of a program. Unlike Python variables, all Unison terms are __immutable__.
+
+``` unison
+aFunction =
+  noReassignments = "Initial value"
+  noReassignments = "🚫 Will not compile, variable is ambiguous."
+```
+
+That means once a variable is introduced, it cannot be changed or reassigned by the program. If you want to update a value, you create a new term which copies the old value and applies the change.
 
 </div>
 <div>
@@ -52,7 +60,7 @@ Python variables are __mutable__ references to values.
 
 ```unison
 aNumber : Int
-aNumber = "🚫 This is a string, so it won't compile"
+aNumber = "🚫 A string being assigned to an Int won't compile"
 ```
 
 Unison is a __statically typed language__, so every definition has a type at compile time. Type signatures can be inferred, but they are often found above the term for clarity. Unison uses `:` to separate the name of the term from its type.
@@ -66,7 +74,7 @@ a_str = 123  # Now it's an int!
 type(a_str)
 ```
 
-In Python, type hints can be used to indicate the expected type of a variable, but they are not enforced at runtime. Python is __dynamically typed__, so a variable can change its type at any time.
+In Python 3, type hints can be used to indicate the expected type of a variable, but they are not enforced at runtime. Python is __dynamically typed__, so a variable can change its type at any time.
 
 </div>
 </div>
@@ -558,17 +566,20 @@ These functions accept the the `Elevator` type as an argument and return a new `
 ```unison
 moveUp : Elevator -> Elevator
 moveUp e = match e with
-  Elevator currentFloor topFloor | currentFloor < topFloor -> Elevator (currentFloor + 1) topFloor
+  Elevator currentFloor topFloor | currentFloor < topFloor ->
+    Elevator (currentFloor + 1) topFloor
   _ -> e
 
 moveDown : Elevator -> Elevator
 moveDown e = match e with
-  Elevator currentFloor topFloor | currentFloor > 0 -> Elevator (currentFloor - 1) topFloor
+  Elevator currentFloor topFloor | currentFloor > 0 ->
+    Elevator (currentFloor - 1) topFloor
   _ -> e
 
 goToFloor : Nat -> Elevator -> Elevator
 goToFloor requested e = match e with
-  Elevator _ topFloor | floor <= topFloor -> Elevator requested topFloor
+  Elevator _ topFloor | floor <= topFloor ->
+    Elevator requested topFloor
   _ -> e
 ```
 
@@ -603,9 +614,9 @@ This class defines an `Elevator` with methods to move up, move down, and go to a
 
 <div class="side-by-side"><div>
 
-### Pipe operator
+### Function composition
 
-In Unison, we use __function composition__ to chain function calls together and advance the state of a program.
+In Unison, we use __function composition__ to chain function calls together and advance the state of a program. The outputs of one function become the inputs to the next.
 
 ``` unison
 e0 = Elevator 0 10
@@ -644,7 +655,7 @@ No arguments are passed to the methods because the `Elevator` instance `e` is im
 
 ## Record types
 
-Unison's record types are similar to Python's dataclasses or namedtuples. They are used to group related data together with named fields, and provide concise dot-syntax for getting and setting fields.
+Unison's __record types__ are similar to Python's __dataclasses__ or `NamedTuples`. They are used to group related data together with named fields, and provide concise dot-syntax for getting and setting fields.
 
 <div class="side-by-side"><div>
 
@@ -663,7 +674,7 @@ Point.y.modify : (Int ->{g} Int) -> Point ->{g} Point
 Point.y.set    : Int -> Point -> Point
 ```
 
-While the following notation looks similar to method calls on an instance of a class, Unison record types are __immutable__. To "change" a field in a record, you create a new record with the updated value using the generated `set` or `modify` functions.
+While the following notation looks similar to method calls on an instance of a class, Unison record types are _immutable_. To "change" a field in a record, you create a new record with the updated value using the generated `set` or `modify` functions.
 
 ```unison
 p1 = Point 3 4
@@ -691,16 +702,59 @@ The `@dataclass` decorator automatically generates special methods like `__init_
 
 </div></div>
 
-## Extending behavior
+## Generic behavior
 
 <div class="side-by-side"><div>
 
-### Generics and parametric polymorphism
+### Parametric polymorphism
 
-All Unison types are __invariant__, meaning they cannot be subclassed or extended. However, you can define new types that contain other types, or use __parametric polymorphism__ to create generic types and functions.
+```unison
+printTwice : (a -> Text) -> a -> {IO, Exception} ()
+printTwice toText x =
+  printLine (toText x)
+  printLine (toText x)
+
+type Duck = Duck
+type RoboDuck = RoboDuck
+
+Duck.quack : Duck -> Text
+Duck.quack _ = "Quack!"
+
+RoboDuck.quack : RoboDuck -> Text
+RoboDuck.quack _ = "Electronic Quack!"
+
+main = do
+  printTwice Duck.quack Duck
+  printTwice RoboDuck.quack RoboDuck
+```
+
+In Unison, __generic types__ allow you to write functions that can operate on any type. They're represented by lowercase letters in type signatures.
+
+In the example above, `printTwice` is a function that takes two arguments: _a function_ that converts a value of any type `a` to `Text`, and a value of type `a`. Because `a` is used as the __type variable__ for both parameters, the same type must be used in both places when calling `printTwice`.
+
+In functional languages, we call this  __parametric polymorphism__.
 
 </div><div>
 
-### Duck typing and inheritance
+### Duck-typing
+
+```python
+def quack_twice(thing):
+    thing.quack()
+    thing.quack()
+
+class Duck:
+    def quack(self): print("Quack!")
+
+class RoboDuck:
+    def quack(self): print("Electronic Quack!")
+
+quack_twice(Duck())
+quack_twice(RobotDuck())
+
+```
+
+Python uses __duck-typing__ to write functions or methods that operate on any object, which means that the expression `thing.quack` will succeed if the object a has a `quack` method, regardless of what it is.
 
 </div></div>
+

--- a/src/compare-lang/unison-for-python-devs.md
+++ b/src/compare-lang/unison-for-python-devs.md
@@ -924,21 +924,21 @@ Renaming or moving definitions between namespaces is common, so don't let the lo
 
 </div><div>
 
-In Python, a file defines a __module__. A module can contain functions, classes, and variables for scoping and imports.
+In Python, a file defines a __module__ and a directory can define a __package__ containing many modules (or sub-packages). The module contains the functions, classes, and variables for the program.
 
 ```python
-# in a file called ./database/user_model.py
+# in a file called ./database/usermodel.py
 
 from typing import Optional
 
 def get_user_name(user_id: int) -> Optional[str]:
-  # implementation goes here
+  ...
 
 def get_user_age(user_id: int) -> Optional[int]:
-  # implementation goes here
+  ...
 ```
 
-Unlike Python, Unison does not use the file system to organize or save code. It is stored via the UCM so definitions can be moved between namespaces without changing the file structure.
+Unlike Python, Unison does not use the file system to organize or save code so the distinction between a package and module is not relevant.
 
 </div></div>
 
@@ -981,13 +981,13 @@ api.getUserAgeJson userId =
 In Python, you can use the `import` statement to bring in modules or specific definitions from modules.
 
 ```python
-# imports the entire user_model module
-from database import user_model
+# imports the entire usermodel module
+from database import usermodel
 
-print(user_model.get_user_name(1))
+print(usermodel.get_user_name(1))
 
-# imports specific functions from the user_model module
-from database.user_model import get_user_name, get_user_age
+# imports specific functions from the usermodel module
+from database.usermodel import get_user_name, get_user_age
 
 print(get_user_name(1))
 ```

--- a/src/compare-lang/unison-for-python-devs.md
+++ b/src/compare-lang/unison-for-python-devs.md
@@ -33,7 +33,7 @@ aFunction =
   noReassignments = "🚫 Will not compile, variable is ambiguous."
 ```
 
-That means once a variable is introduced, it cannot be changed or reassigned by the program. If you want to update a value, you create a new term which copies the old value and applies the change.
+That means once a variable is introduced, it cannot be changed or reassigned by the program. To update a value, you create a new term that copies the old value and applies the change.
 
 </div>
 <div>
@@ -86,7 +86,7 @@ In Python 3, type hints can be used to indicate the expected type of a variable,
 <div class="side-by-side">
 <div>
 
-Unison's tuple type can hold an arbitary fixed number of values, each of potentially different types. Tuple elements are accessed using `at1`, `at2`, etc. for the first, second, and subsequent elements.
+Unison's tuple type can hold an arbitrary fixed number of values, each of potentially different types. Tuple elements are accessed using `at1`, `at2`, etc., for the first, second, and subsequent elements.
 
 ```unison
 aTuple : (Text, Nat, Int)
@@ -96,7 +96,7 @@ first = at1 aTuple
 second = at2 aTuple
 ```
 
-You cannot unpack a tuple at the top level of a file, outside of a function body, however, _inside_ a function body, for local variable assignments, you can decompose a tuple like this:
+You cannot unpack a tuple at the top level of a file, outside of a function body. However, _inside_ a function body, for local variable assignments, you can decompose a tuple like this:
 
 ```unison
 foo =
@@ -168,7 +168,7 @@ a_dict = {"🍎": "value1", "🫐": 100, "🍐": True}
 a_frozen_set = frozenset([1, -2, 3, -4, 5])
 ```
 
-Dictionary keys in Python must be hashable. In Unison there is no restriction on key types in a `Map`.
+Dictionary keys in Python must be hashable. In Unison, there is no restriction on key types in a `Map`.
 
 In Python, you might use `frozenset` or tuples for immutable collections. This operation on a dictionary will change the original collection.
 
@@ -327,7 +327,7 @@ myFunc n =
 
 ## The basics
 
-Unison and Python are both whitespace significant languages. Indentation is used to indicate blocks of code, such as function bodies and control flow statements.
+Unison and Python are both whitespace-significant languages. Indentation is used to indicate blocks of code, such as function bodies and control flow statements.
 
 <div class="side-by-side"><div>
 
@@ -391,7 +391,7 @@ hooray a b num =
   Text.repeat repeat (a ++ b ++ "!!!")
 ```
 
-Unison does not allow default values for function arguments. Instead you might use the `Optional` type to indicate that an argument is optional, and then provide a default value inside the function body.
+Unison does not allow default values for function arguments. Instead, you might use the `Optional` type to indicate that an argument is optional, and then provide a default value inside the function body.
 
 </div><div>
 
@@ -566,7 +566,7 @@ safeDivide a b =
   else a / b
 ```
 
-In Unison, we use special functions called __ability handlers__ to manage effects. Here, we use the `catch` function to turn the potential exception into the `Either` data-type.
+In Unison, we use special functions called __ability handlers__ to manage effects. Here, we use the `catch` function to turn the potential exception into the `Either` data type.
 
 ```unison
 catchSafeDivide : Nat -> Nat -> Either Failure Nat
@@ -574,7 +574,7 @@ catchSafeDivide a b =
   catch do safeDivide a b
 ```
 
-Alternatively, we can continue to propagate the exception to the caller by including `{Exception}` in enclosing function's ability set:
+Alternatively, we can continue to propagate the exception to the caller by including `{Exception}` in the enclosing function's ability set:
 
 ```unison
 callingSafeDivide : '{Exception} Text
@@ -609,7 +609,7 @@ def run_with_catch(a, b):
     return None
 ```
 
-Python's **try...except** blocks are similar to _ability handler_ functions in Unison in that they specify that a code block may be performing an effect and then specify how the runtime should respond. However, `try...except` are built in to the Python language, whereas Unison handler functions are generalizeable and developer defined.
+Python's **try...except** blocks are similar to _ability handler_ functions in Unison in that they specify that a code block may be performing an effect and then specify how the runtime should respond. However, `try...except` is built into the Python language, whereas Unison handler functions are generalizable and defined by developers.
 
 </div></div>
 
@@ -629,7 +629,7 @@ This is a __type declaration__ for an `Elevator` that tracks the current floor a
 type Elevator = Elevator Nat Nat
 ```
 
-These functions accept the the `Elevator` type as an argument and return a new `Elevator` with updated state.
+These functions accept the `Elevator` type as an argument and return a new `Elevator` with updated state.
 
 ```unison
 moveUp : Elevator -> Elevator
@@ -708,7 +708,7 @@ Each transformation is applied in sequence, allowing for a clear flow of data th
 
 ### Dot notation
 
-The dot notation in Python expresses method calls on an object which may _mutate_ the object's internal state.
+The dot notation in Python expresses method calls on an object that may _mutate_ the object's internal state.
 
 ```python
 e = Elevator()
@@ -832,7 +832,7 @@ Unison does not support inheritance or subtyping. All types are _invariant_. But
 type Duck = AnimalDuck | RoboDuck Text | ToyDuck Text
 ```
 
-The `type` declaration means that the `Duck` type has three _data constructors_. The "AnimalDuck" which does not have a special noise, but the other two data constructors (`RoboDuck` and `ToyDuck`) take a `Text` argument representing the special behavior of that case (a quack prefix in this example).
+The `type` declaration means that the `Duck` type has three _data constructors_. The `AnimalDuck` does not make a special noise, but the other two data constructors (`RoboDuck` and `ToyDuck`) take a `Text` argument representing the specific behavior of that case (a quack prefix in this example).
 
 ```unison
 Duck.toText : Duck -> Text
@@ -897,7 +897,7 @@ quack_twice(ToyDuck("Squeaky"))
 
 <div class="side-by-side"><div>
 
-In Unison, a __namespace__ is a collection of related definitions, which can be functions, types, or other namespaces. Namespaces are introduced by giving terms a dot-separated prefix when when they are defined:
+In Unison, a __namespace__ is a collection of related definitions, which can be functions, types, or other namespaces. Namespaces are introduced by giving terms a dot-separated prefix when they are defined:
 
 ```unison
 database.userModel.getUserName : Nat -> Optional Text

--- a/src/compare-lang/unison-for-python-devs.md
+++ b/src/compare-lang/unison-for-python-devs.md
@@ -197,10 +197,10 @@ List.map (x -> x * 2) [1, 2, 3]
 Lambdas in Unison can include local variable assignments and multiple expressions:
 
 ```unison
-List.foldLeft 0 (acc x -> let
+List.foldLeft (acc x -> let
   double = x * 2
   acc + double
-) [1, 2, 3]
+) 0 [1, 2, 3]
 ```
 
 The `let` keyword is a way of starting a code block in Unison.
@@ -240,8 +240,8 @@ optionalNone = None
 foo : Optional Text -> Text
 foo bar =
   match bar with
-  | Some text -> "Value provided: " ++ text
-  | None -> "No value provided"
+    Some text -> "Value provided: " ++ text
+    None -> "No value provided"
 ```
 
 The `match` expression is used to destructure the `Optional` type. You cannot use the value inside an `Optional` without pattern matching on it or using a function that unwraps the `Optional` type.
@@ -410,7 +410,7 @@ Python allows default values for function arguments, which can be specified in t
 ```unison
 hoorayMany : [Text] -> Text
 hoorayMany texts =
-  Text.intercalate " " texts ++ "!!!"
+  Text.join " " texts ++ "!!!"
 ```
 
 Unison does not have built-in support for variadic functions. Instead, you can accept a list of values as an argument.
@@ -558,10 +558,10 @@ The key difference is how each language treats effects (operations that go beyon
 In Unison, the effects a function may perform are part of its type signature. `{Exception}` indicates that this function might throw an exception.
 
 ```unison
-safeDivide : Int -> Int ->{Exception} Int
+safeDivide : Nat -> Nat ->{Exception} Nat
 safeDivide a b =
   use Int /
-  if b === +0
+  if b === 0
   then Exception.raise (failure "cannot divide by zero" b)
   else a / b
 ```
@@ -569,7 +569,7 @@ safeDivide a b =
 In Unison, we use special functions called __ability handlers__ to manage effects. Here, we use the `catch` function to turn the potential exception into the `Either` data-type.
 
 ```unison
-catchSafeDivide : Int -> Int -> Either Failure Int
+catchSafeDivide : Nat -> Nat -> Either Failure Nat
 catchSafeDivide a b =
   catch do safeDivide a b
 ```
@@ -579,7 +579,7 @@ Alternatively, we can continue to propagate the exception to the caller by inclu
 ```unison
 callingSafeDivide : '{Exception} Text
 callingSafeDivide = do
-  (Int.toText (safeDivide 10 0))
+  (Nat.toText (safeDivide 10 5))
 ```
 
 At the entry point of a Unison program, only the `IO` and `Exception` abilities are allowed. All other effects must be handled by:
@@ -646,7 +646,7 @@ moveDown e = match e with
 
 goToFloor : Nat -> Elevator -> Elevator
 goToFloor requested e = match e with
-  Elevator _ topFloor | floor <= topFloor ->
+  Elevator _ topFloor | requested <= topFloor ->
     Elevator requested topFloor
   _ -> e
 ```
@@ -816,7 +816,6 @@ class RoboDuck:
 
 quack_twice(Duck())
 quack_twice(RobotDuck())
-
 ```
 
 Python uses __duck-typing__ to write functions or methods that operate on any object, which means that the expression `thing.quack` will succeed if the object a has a `quack` method, regardless of what it is.
@@ -852,7 +851,7 @@ quacks = do
   printTwice Duck.toText (Duck.ToyDuck "Squeaky")
 ```
 
-Note that `Duck.AnimalDuck`, `Duck.RoboDuck`, and `Duck.ToyDuck` are functions that are used to create values with the `Duck` type when provided with their respective arguments. They are not distinct types themselves.
+Note that `AnimalDuck`, `RoboDuck`, and `ToyDuck` are functions that are used to create values with the `Duck` type when provided with their respective arguments. They are not distinct types themselves.
 
 </div><div>
 
@@ -958,7 +957,7 @@ use database.userModel
    full namespace prefix -}
 api.getUserNameJson : Nat -> Json
 api.getUserNameJson userId =
-  getUserName userId
+  name = getUserName userId
   todo "..."
 
 -- Only imports the getUserAge definition
@@ -1058,7 +1057,7 @@ Everything in your file and in your current project is in scope.
 <div class="side-by-side"><div>
 
 ```unison
-factorial n = product (range 1 (n + 1))
+factorial n = Nat.product (range 1 (n + 1))
 
 > factorial 3
 ```

--- a/src/compare-lang/unison-for-python-devs.md
+++ b/src/compare-lang/unison-for-python-devs.md
@@ -130,7 +130,7 @@ aList : List Nat
 aList = [1, 2, 3, 4, 5]
 
 aMap : Map Text Text
-aMap = [("🍎", "value1"), ("🫐", "100"), ("🍐", "true")] |> Map.fromList
+aMap = Map.fromList [("🍎", "a"), ("🫐", "100"), ("🍐", "true")]
 
 aSet : Set Int
 aSet = Set.fromList [+1, -2, +3, -4, +5]
@@ -138,7 +138,7 @@ aSet = Set.fromList [+1, -2, +3, -4, +5]
 
 Unison does not have special syntax for creating `Maps` or `Sets`, so they are often created from a list of tuples.
 
-In Unison, the following does not mutate the original `Map`. It creates a new `Map` and binds it to a variable:
+In Unison, the following does not mutate the original `Map`. Inserting the new key and value creates a new `Map` and binds it to a variable:
 
 ```unison
 map1 = Map.fromList [("💙", 1), ("🩷", 12), ("💚", 35)]
@@ -157,6 +157,8 @@ a_dict = {"🍎": "value1", "🫐": 100, "🍐": True}
 
 a_frozen_set = frozenset([1, -2, 3, -4, 5])
 ```
+
+Dictionary keys in Python must be hashable. In Unison there is no restriction on key types in a `Map`.
 
 In Python, you might use `frozenset` or tuples for immutable collections. This operation on a dictionary will change the original collection.
 
@@ -214,7 +216,7 @@ Lambdas in Python can't include local variable definitions or mupltiple expressi
 </div></div>
 
 ## Optional values
-Unison has a type called `Optional` that can either be `Some value` or `None`. It's is similar to Python's `Optional` union type from the `typing` module.
+Unison has a type called `Optional` that can either be `Some value` or `None`. It's is similar to Python's `Optional` type from the `typing` module.
 
 <div class="side-by-side">
 <div>
@@ -292,12 +294,12 @@ Python uses `None` as the type for functions that do not explicitly return somet
    in Unison -}
 ```
 
-Caveat: Unison comments are not saved to the codebase as part of the definition. Create a string literal if you would like to include a note that is saved with the implementation.
+⚠️ Unison comments are not saved to the codebase as part of the definition. Create a string literal if you would like to include a note that is saved with the implementation.
 
 ``` unison
 myFunc : Nat -> Nat
 myFunc n =
-  _ = "This function doubles a number"
+  _ = "This expression doubles a number"
   n * 2
 ```
 </div><div>
@@ -367,6 +369,57 @@ hooray("Hello", "world")
 ```
 
 In Python, functions are called with parentheses and arguments are separated by commas.
+</div></div>
+
+## Function arguments
+
+### Default arguments
+
+<div class="side-by-side"><div>
+
+``` unison
+hooray : Text -> Text -> Optional Nat -> Text
+hooray a b num =
+  repeat = Optional.getOrElse 1 num
+  Text.repeat repeat (a ++ b ++ "!!!")
+```
+
+Unison does not allow default values for function arguments. Instead you might use the `Optional` type to indicate that an argument is optional, and then provide a default value inside the function body.
+
+</div><div>
+
+```python
+def hooray(a: str, b: str, repeat: int = 1) -> str:
+  combined = a + b + "!!!"
+  return combined * repeat
+```
+
+Python allows default values for function arguments, which can be specified in the function definition.
+
+</div></div>
+
+### Variadic arguments
+
+<div class="side-by-side"><div>
+
+```unison
+hoorayMany : [Text] -> Text
+hoorayMany texts =
+  Text.intercalate " " texts ++ "!!!"
+```
+
+Unison does not have built-in support for variadic functions. Instead, you can accept a list of values as an argument.
+
+</div><div>
+
+```python
+def hooray_many(*texts: str) -> str:
+  combined = " ".join(texts) + "!!!"
+  return combined
+```
+
+Python supports variadic functions using the `*args` syntax, which allows you to pass a variable number of arguments to a function.
+
 </div></div>
 
 # Control flow
@@ -506,7 +559,7 @@ moveDown e =
 goToFloor : Nat -> Elevator -> Elevator
 goToFloor requested e =
   if requested <= topFloor e then
-    Elevator.set (currentFloor -> floor) e
+    Elevator.set requested e
   else
     e
 ```
@@ -581,7 +634,7 @@ In Python, dot notation is used to call methods on objects. Each method call can
 
 ## Record types
 
-Unison's record types are similar to Python's dataclasses or namedtuples. They are used to group related data together, and provide concise dot-syntax for getting and setting fields.
+Unison's record types are similar to Python's dataclasses or namedtuples. They are used to group related data together with named fields, and provide concise dot-syntax for getting and setting fields.
 
 <div class="side-by-side"><div>
 
@@ -589,7 +642,24 @@ Unison's record types are similar to Python's dataclasses or namedtuples. They a
 type Point = {x : Int, y : Int}
 ```
 
-This defines a `Point` type with two fields, `x` and `y`, both of type `Int`. You can create instances of this type and access or modify its fields using generated functions.
+This defines a `Point` type with two fields, `x` and `y`, both of type `Int`. Defining a record type creates the following accessor and modifier functions:
+
+```unison
+Point.x        : Point -> Int
+Point.x.modify : (Int ->{g} Int) -> Point ->{g} Point
+Point.x.set    : Int -> Point -> Point
+Point.y        : Point -> Int
+Point.y.modify : (Int ->{g} Int) -> Point ->{g} Point
+Point.y.set    : Int -> Point -> Point
+```
+
+While the following notation looks similar to method calls on an instance of a class, Unison record types are __immutable__. To "change" a field in a record, you create a new record with the updated value using the generated `set` or `modify` functions.
+
+```unison
+p1 = Point 3 4
+p2 = Point.x.set 10 p1
+-- p2 is now Point 10 4, p1 is still Point 3 4
+```
 
 </div><div>
 

--- a/src/compare-lang/unison-for-python-devs.md
+++ b/src/compare-lang/unison-for-python-devs.md
@@ -760,8 +760,9 @@ class Point(NamedTuple):
   y: int
 
 p1 = Point(3, -4)
-x = p1.x  # Accessing the x field
-p2 = p1._replace(x=10)  # Creating a new Point with an updated x field
+x = p1.x # Accessing the x field
+p2 = p1._replace(x=10)
+# Creating a new Point with an updated x field
 ```
 
 </div></div>
@@ -1047,21 +1048,19 @@ $ python my_script.py
 
 ### The REPL
 
-Unison uses **watch expressions** to interactively evaluate code, instead of a traditional REPL. Watch expressions let you test and explore code directly in your source files.
+Unison uses **watch expressions** to interactively evaluate code, instead of a traditional **REPL**. Watch expressions let you test and explore code directly in your source files.
+
+<div class="side-by-side"><div>
 
 The Unison Codebase Manager (UCM) watches for changes to `.u` files and evaluates any lines starting with `>` in the file as a watch expression. The expressions must be "pure", meaning they cannot perform side effects like `IO` or throwing exceptions.
 
-Everything in your file and in your current project is in scope.
-
-<div class="side-by-side"><div>
 
 ```unison
 factorial n = Nat.product (range 1 (n + 1))
 
 > factorial 3
 ```
-
-UCM will print out:
+Everything in your file and in your current UCM project is in scope. The UCM will print to the console like this:
 
 ```unison
 > factorial 3
@@ -1071,7 +1070,7 @@ UCM will print out:
 
 </div><div>
 
-Python has a traditional **REPL** that allows you to enter and evaluate code interactively.
+Python has a traditional REPL that allows you to enter and evaluate code interactively.
 
 ```python
 >>> factorial = lambda n: 1 if n == 0 else n * factorial(n - 1)

--- a/src/compare-lang/unison-for-python-devs.md
+++ b/src/compare-lang/unison-for-python-devs.md
@@ -1,0 +1,557 @@
+---
+layout: "compare-lang"
+title: "Unison for Python devs"
+description: "Comparing syntax and patterns between Unison and Python"
+---
+
+[[toc]]
+
+# Variables
+
+<div class="side-by-side">
+<div>
+
+```unison
+aText : Text
+aText = "Hello, world!"
+
+aNat : Nat
+aNat = 123
+
+anInt : Int
+anInt = +123
+
+aBoolean : Boolean
+aBoolean = true || false
+```
+
+Unison terms can be defined at the top level of a program. Unlike Python variables, all Unison terms are __immutable__.
+
+</div>
+<div>
+
+```python
+a_string = "Hello, world!"
+
+an_int = 123
+
+a_float = 3.14
+
+a_boolean = True or False
+
+a_reassignment = "initial value"
+a_reassignment = "new value"
+```
+
+Python variables are __mutable__ references to values.
+
+</div>
+</div>
+
+<div class="side-by-side"><div>
+
+```unison
+aNumber : Int
+aNumber = "🚫 This is a string, so it won't compile"
+```
+
+Unison is a __statically typed language__, so every definition has a type at compile time. Type signatures can be inferred, but they are often found above the term for clarity. Unison uses `:` to separate the name of the term from its type.
+
+</div><div>
+
+```python
+a_str = str("Is this a string?")
+type(a_str)
+a_str = 123  # Now it's an int!
+type(a_str)
+```
+
+In Python, type hints can be used to indicate the expected type of a variable, but they are not enforced at runtime. Python is __dynamically typed__, so a variable can change its type at any time.
+
+</div>
+</div>
+
+## Tuples
+
+<div class="side-by-side">
+<div>
+
+Unison's tuple type can hold an arbitary fixed number of values, each of potentially different types. Tuple elements are accessed using `at1`, `at2`, etc. for the first, second, and subsequent elements.
+
+```unison
+aTuple : (Text, Nat, Int)
+aTuple = ("📘", 2, -100)
+
+first = at1 aTuple
+second = at2 aTuple
+```
+
+You cannot unpack a tuple at the top level of a file, outside of a function body, however, _inside_ a function body, for local variable assignments, you can decompose a tuple like this:
+
+```unison
+foo =
+  aTuple = ("📘", 2, -100)
+  (first, second, third) = aTuple
+  first ++ (Nat.toText second) ++ (Int.toText third)
+```
+
+</div>
+<div>
+
+Both Python and Unison tuples are immutable.
+
+In Python, accessing tuple elements is done with zero-based indexing.
+
+```python
+a_tuple = ("📘", 2, -100)
+
+first = a_tuple[0]
+second = a_tuple[1]
+```
+
+Unpacking a tuple in Python looks like this:
+
+```python
+a_tuple = ("📘", 2, -100)
+(first, second, third) = a_tuple
+```
+
+</div></div>
+
+## Collections
+
+<div class="side-by-side">
+<div>
+
+Unison collections are immutable by default and cannot contain values of different types.
+
+```unison
+aList : List Nat
+aList = [1, 2, 3, 4, 5]
+
+aMap : Map Text Text
+aMap = [("🍎", "value1"), ("🫐", "100"), ("🍐", "true")] |> Map.fromList
+
+aSet : Set Int
+aSet = Set.fromList [+1, -2, +3, -4, +5]
+```
+
+Unison does not have special syntax for creating `Maps` or `Sets`, so they are often created from a list of tuples.
+
+In Unison, the following does not mutate the original `Map`. It creates a new `Map` and binds it to a variable:
+
+```unison
+map1 = Map.fromList [("💙", 1), ("🩷", 12), ("💚", 35)]
+map2 = Map.insert "💛" 100 map1
+```
+
+</div>
+<div>
+
+Python collections like lists and dicts are mutable by default. The types of values in a collection can vary.
+
+```python
+a_list = [1, 2, 3, 4, 5]
+
+a_dict = {"🍎": "value1", "🫐": 100, "🍐": True}
+
+a_frozen_set = frozenset([1, -2, 3, -4, 5])
+```
+
+In Python, you might use `frozenset` or tuples for immutable collections. This operation on a dictionary will change the original collection.
+
+```python
+map_1 = {"💙": 1, "🩷": 12, "💚": 35}
+map_1["💛"] = 100
+```
+
+</div>
+</div>
+
+## List expressions
+
+<div class="side-by-side"><div>
+
+### Lambdas
+
+This expression doubles each number in the list. Unison uses higher-order functions like `List.map` to transform data.
+
+```unison
+List.map (x -> x * 2) [1, 2, 3]
+```
+
+`(x -> x * 2)` is a __lambda__ (an anonymous function) that takes one argument `x` and returns `x * 2`.
+
+Lambdas in Unison can include local variable assignments and multiple expressions:
+
+```unison
+List.foldLeft 0 (acc x -> let
+  double = x * 2
+  acc + double
+) [1, 2, 3]
+```
+
+The `let` keyword is a way of starting a code block in Unison.
+
+</div><div>
+
+### List comprehensions
+
+In Python, you might use a __list comprehension__ to iterate over elements in a list and create a new one:
+
+```python
+[x * 2 for x in [1, 2, 3]]
+```
+
+Here's the same expression using the `map` function and a lambda:
+
+```python
+list(map(lambda x: x * 2, [1, 2, 3]))
+```
+
+Lambdas in Python can't include local variable definitions or mupltiple expressions, so they are typically used for simple transformations.
+
+</div></div>
+
+## Optional values
+Unison has a type called `Optional` that can either be `Some value` or `None`. It's is similar to Python's `Optional` union type from the `typing` module.
+
+<div class="side-by-side">
+<div>
+
+```unison
+optionalSome : Optional Text
+optionalSome = Some "Hello, world!"
+
+optionalNone : Optional Text
+optionalNone = None
+
+foo : Optional Text -> Text
+foo bar =
+  match bar with
+  | Some text -> "Value provided: " ++ text
+  | None -> "No value provided"
+```
+
+The `match` expression is used to destructure the `Optional` type. You cannot use the value inside an `Optional` without pattern matching on it or using a function that unwraps the `Optional` type.
+
+</div>
+<div>
+
+```python
+from typing import Optional
+
+def foo(bar: Optional[str]) -> str:
+  if bar is None:
+    return "No value provided"
+  return f"Value provided: {bar}!"
+```
+
+In Python, `None` is a singleton object representing the absence of a value at runtime. It is similar to `Optional.None` in that both address nullability, but it is not tracked by the type system, so after a check for `None`, you can use the value directly.
+
+</div></div>
+
+
+<div class="side-by-side"><div>
+
+### Unit
+
+```unison
+unit : ()
+unit = ()
+
+greet : Text -> {IO, Exception} ()
+greet name =
+  printLine ("Hello " ++ name)
+```
+
+Unison uses the `Unit` type, `()`, to represent a function that does not return a meaningful value. It's often used in places where a function is performing an action, such as printing to the console.
+
+</div><div>
+
+### None
+
+```python
+def greet(name: str) -> None:
+  print "Hello " + name
+```
+
+Python uses `None` as the type for functions that do not explicitly return something.
+
+</div></div>
+
+# Functions
+
+## The basics
+
+Unison and Python are both whitespace significant languages. Indentation is used to indicate blocks of code, such as function bodies and control flow statements.
+
+<div class="side-by-side"><div>
+
+```unison
+hooray : Text -> Text -> Text
+hooray a b  =
+  a ++ b ++ "!!!"
+```
+
+* Unison does not have a special keyword for defining a function.
+* In the type signature, arguments are separated by arrows, with the last type being the return type of the entire function.
+* There are no explicit return statements in Unison. The _last expression_ in a function is the return value.
+
+</div><div>
+
+```python
+def hooray(a: str, b: str) -> int:
+  return a + b + "!!!"
+```
+
+* Python defines functions using the `def` keyword
+* When type hints are provided, they're located inline with the function arguments.
+* The `return` keyword is used to _explicitly_ return a value from a function.
+
+</div></div>
+
+## Calling functions
+
+<div class="side-by-side"><div>
+
+```unison
+hooray "Hello" "world"
+```
+
+Unison functions are called _without parentheses_ by default. Function arguments are separated by spaces.
+
+``` unison
+hooray "Happy" ((Nat.toText 1) ++ "st birthday")
+```
+
+Parentheses are used to enforce the order of evaluation when necessary.
+
+
+</div><div>
+
+```python
+hooray("Hello", "world")
+```
+
+In Python, functions are called with parentheses and arguments are separated by commas.
+</div></div>
+
+# Control flow
+
+## Conditionals
+
+<div class="side-by-side"><div>
+
+```unison
+conditional : Nat -> Nat -> Text
+conditional a b =
+  if a > b then
+    "a is greater than b"
+  else if a < b then
+    "a is less than b"
+  else
+    "a is equal to b"
+```
+
+Unison uses `if` `then` and `else` for conditional expressions. Both the `then` and `else` branches must return the _same type_. Unlike Python, the `else` branch is always required.
+</div><div>
+
+```python
+def conditional(a: int, b: int) -> str:
+  if a > b:
+    return "a is greater than b"
+  elif a < b:
+    return "a is less than b"
+  else:
+    return "a is equal to b"
+```
+
+Python uses `if`, `elif`, and `else` for conditional expressions.
+
+```python
+def print_positive(num):
+  if num > 0:
+    print("Positive number")
+  return -100
+```
+
+The `else` branch is optional, and the branches can return different types.
+
+</div></div>
+
+## Pattern matching
+
+Pattern matching in Unison is a powerful feature that allows you to destructure data types and match against specific patterns. It is similar to switch statements in other languages and it's often used in favor of nested conditional statements.
+
+<div class="side-by-side"><div>
+
+Unison supports structural pattern matching using the `match ... with` syntax.
+
+```unison
+describeNat : Nat -> Text
+describeNat n =
+  match n with
+    0 -> "zero"
+    1 -> "one"
+    _ -> "many"
+```
+
+The underscore `_` is a wildcard that matches any value not explicitly matched by the previous patterns.
+
+All patterns must be __exhaustive__, meaning that every possible value of the type must be handled. If a pattern is not matched, the code will not compile.
+
+</div><div>
+
+Python has introduced structural pattern matching with the `match ... case` syntax.
+
+```python
+def describe_num(n: int) -> str:
+  match n:
+    case 0:
+      return "zero"
+    case 1:
+      return "one"
+    case _:
+      return "many"
+```
+
+Python's match does __not enforce exhaustiveness__.
+</div></div>
+
+### Pattern guards
+
+<div class="side-by-side"><div>
+
+```unison
+sign : Int -> Text
+sign n =
+  match n with
+    x | x > +0 -> "positive"
+    x | x < +0 -> "negative"
+    _ -> "zero"
+```
+
+In Unison, pattern guards add additional conditions to a `case` using the `|` symbol:
+
+</div><div>
+
+``` python
+def sign(n: int) -> str:
+  match n:
+    case x if x > 0:
+      return "positive"
+    case x if x < 0:
+      return "negative"
+    case _:
+      return "zero"
+```
+
+Python uses `if` in a `case` clause for the same purpose.
+
+</div>
+</div>
+
+# Objects and classes
+
+🌌🔭 While this is a vast topic, here are a few differences between Unison and Python in terms of object-oriented programming (OOP) and functional programming (FP) patterns.
+
+<div class="side-by-side"><div>
+
+## Data types and functions
+
+Unison does not have classes in the same way that Python does. Instead, we use __data types__ which structure and contain data and __functions__ to transform them.
+
+```unison
+type Elevator = {currentFloor : Nat, topFloor : Nat}
+
+moveUp : Elevator -> Elevator
+moveUp e =
+  Elevator.modify (currentFloor -> if currentFloor < topFloor e then currentFloor + 1 else currentFloor) e
+
+moveDown : Elevator -> Elevator
+moveDown e =
+  Elevator.modify (currentFloor -> if currentFloor > 0 then currentFloor - 1 else currentFloor) e
+
+goToFloor : Nat -> Elevator -> Elevator
+goToFloor requested e =
+  if requested <= topFloor e then
+    Elevator.set (currentFloor -> floor) e
+  else
+    e
+```
+
+These functions accept the the `Elevator` type as an argument and return a new `Elevator` with updated state.
+
+</div><div>
+
+## Methods and instance variables
+
+Python uses __classes__ to __encapsulate__ both data and behavior. Methods are defined within classes and operate on the data contained in instances of those classes.
+
+```python
+class Elevator:
+    def __init__(self, current_floor: int = 0, top_floor: int = 10):
+        self.current_floor = current_floor
+        self.top_floor = top_floor
+
+    def move_up(self):
+        if self.current_floor < self.top_floor:
+            self.current_floor += 1
+
+    def move_down(self):
+        if self.current_floor > 0:
+            self.current_floor -= 1
+
+    def go_to_floor(self, floor: int):
+        if 0 <= floor <= self.top_floor:
+            self.current_floor = floor
+```
+
+This class defines an `Elevator` with methods to move up, move down, and go to a specific floor. The state of the elevator is stored and changed in instance variables.
+
+</div></div>
+
+
+<div class="side-by-side"><div>
+
+### Pipe operator
+
+```unison
+Elevator 0 10
+  |> goToFloor 5
+  |> moveUp
+  |> moveDown
+```
+
+In Unison, the `|>` operator is used to pipe the result of one expression into the next as its argument. Each transformation is applied in sequence, allowing for a clear flow of data through inputs and outputs without intermediate variables.
+
+With intermediate variables, the same example would look like this:
+
+``` unison
+e0 = Elevator 0 10
+e1 = goToFloor 5 e0
+e2 = moveUp e1
+e3 = moveUp e2
+```
+
+</div><div>
+
+### Dot notation
+
+```python
+e = Elevator()
+e.go_to_floor(5)
+e.move_up()
+e.move_down()
+```
+
+In Python, dot notation is used to call methods on objects. Each method call can modify the object's internal state (mutating it in place) or return a new value. Unlike Unison's `|>` operator, there is no implicit piping of results—each call operates on the object referenced by the variable.
+
+</div></div>
+
+## Inheritance
+
+In Python, extending the behavior of a class can be accomplished via subclassing or __inheritance__.
+
+All Unison types are __invariant__, meaning they cannot be subclassed or extended. However, you can define new types that contain other types.

--- a/src/compare-lang/unison-for-python-devs.md
+++ b/src/compare-lang/unison-for-python-devs.md
@@ -6,7 +6,7 @@ description: "Comparing syntax and patterns between Unison and Python"
 
 [[toc]]
 
-# Variables
+# Variables and expressions
 
 <div class="side-by-side">
 <div>
@@ -280,6 +280,38 @@ Python uses `None` as the type for functions that do not explicitly return somet
 
 </div></div>
 
+# Comments
+
+<div class="side-by-side"><div>
+
+```unison
+-- This is a single-line comment in Unison
+
+{- This is a
+   multi-line comment
+   in Unison -}
+```
+
+Caveat: Unison comments are not saved to the codebase as part of the definition. Create a string literal if you would like to include a note that is saved with the implementation.
+
+``` unison
+myFunc : Nat -> Nat
+myFunc n =
+  _ = "This function doubles a number"
+  n * 2
+```
+</div><div>
+
+```python
+# This is a single-line comment in Python
+
+"""This is a
+   multi-line comment
+   in Python"""
+```
+
+</div></div>
+
 # Functions
 
 ## The basics
@@ -452,9 +484,7 @@ Python uses `if` in a `case` clause for the same purpose.
 </div>
 </div>
 
-# Objects and classes
-
-🌌🔭 While this is a vast topic, here are a few differences between Unison and Python in terms of object-oriented programming (OOP) and functional programming (FP) patterns.
+# Classes and types
 
 <div class="side-by-side"><div>
 
@@ -485,7 +515,7 @@ These functions accept the the `Elevator` type as an argument and return a new `
 
 </div><div>
 
-## Methods and instance variables
+## Classes and methods
 
 Python uses __classes__ to __encapsulate__ both data and behavior. Methods are defined within classes and operate on the data contained in instances of those classes.
 
@@ -511,7 +541,6 @@ class Elevator:
 This class defines an `Elevator` with methods to move up, move down, and go to a specific floor. The state of the elevator is stored and changed in instance variables.
 
 </div></div>
-
 
 <div class="side-by-side"><div>
 
@@ -546,12 +575,43 @@ e.move_up()
 e.move_down()
 ```
 
-In Python, dot notation is used to call methods on objects. Each method call can modify the object's internal state (mutating it in place) or return a new value. Unlike Unison's `|>` operator, there is no implicit piping of results—each call operates on the object referenced by the variable.
+In Python, dot notation is used to call methods on objects. Each method call can modify the object's internal state (mutating it in place) or return a new value.
 
 </div></div>
+
+## Record types
+
+Unison's record types are similar to Python's dataclasses or namedtuples. They are used to group related data together, and provide concise dot-syntax for getting and setting fields.
+
+<div class="side-by-side"><div>
+
+```unison
+type Point = {x : Int, y : Int}
+```
+
+This defines a `Point` type with two fields, `x` and `y`, both of type `Int`. You can create instances of this type and access or modify its fields using generated functions.
+
+</div><div>
+
+```python
+from dataclasses import dataclass
+from typing import NamedTuple
+
+@dataclass
+class Point:
+  x: int
+  y: int
+
+class Point(NamedTuple):
+  x: int
+  y: int
+```
+
+The `@dataclass` decorator automatically generates special methods like `__init__()` and `__repr__()` for the class. `NamedTuple` creates an immutable class with similar benefits.
 
 ## Inheritance
 
 In Python, extending the behavior of a class can be accomplished via subclassing or __inheritance__.
 
 All Unison types are __invariant__, meaning they cannot be subclassed or extended. However, you can define new types that contain other types.
+

--- a/src/compare-lang/unison-for-python-devs.md
+++ b/src/compare-lang/unison-for-python-devs.md
@@ -294,7 +294,7 @@ Python uses `None` as the type for functions that do not explicitly return somet
    in Unison -}
 ```
 
-⚠️ Unison comments are not saved to the codebase as part of the definition. Create a string literal if you would like to include a note that is saved with the implementation.
+Unison comments are not saved to the codebase as part of the definition. Create a string literal if you would like to include a note that is saved with the implementation.
 
 ``` unison
 myFunc : Nat -> Nat
@@ -537,34 +537,40 @@ Python uses `if` in a `case` clause for the same purpose.
 </div>
 </div>
 
-# Classes and types
+# Data modeling
+
+🌌🔭This topic is vast, but here are some of the key differences between Unison and Python when it comes to modeling data.
 
 <div class="side-by-side"><div>
 
-## Data types and functions
+## Types and functions
 
-Unison does not have classes in the same way that Python does. Instead, we use __data types__ which structure and contain data and __functions__ to transform them.
+Unison does not have classes in the same way that Python does. There are no instance methods, no constructors, and no `self` or `this` references. Instead, we use __data types__ which structure and contain data and __functions__ which transform them to describe behavior.
+
+This is a __type declaration__ for an `Elevator` that tracks the current floor and the top floor of the building:
 
 ```unison
-type Elevator = {currentFloor : Nat, topFloor : Nat}
-
-moveUp : Elevator -> Elevator
-moveUp e =
-  Elevator.modify (currentFloor -> if currentFloor < topFloor e then currentFloor + 1 else currentFloor) e
-
-moveDown : Elevator -> Elevator
-moveDown e =
-  Elevator.modify (currentFloor -> if currentFloor > 0 then currentFloor - 1 else currentFloor) e
-
-goToFloor : Nat -> Elevator -> Elevator
-goToFloor requested e =
-  if requested <= topFloor e then
-    Elevator.set requested e
-  else
-    e
+type Elevator = Elevator Nat Nat
 ```
 
 These functions accept the the `Elevator` type as an argument and return a new `Elevator` with updated state.
+
+```unison
+moveUp : Elevator -> Elevator
+moveUp e = match e with
+  Elevator currentFloor topFloor | currentFloor < topFloor -> Elevator (currentFloor + 1) topFloor
+  _ -> e
+
+moveDown : Elevator -> Elevator
+moveDown e = match e with
+  Elevator currentFloor topFloor | currentFloor > 0 -> Elevator (currentFloor - 1) topFloor
+  _ -> e
+
+goToFloor : Nat -> Elevator -> Elevator
+goToFloor requested e = match e with
+  Elevator _ topFloor | floor <= topFloor -> Elevator requested topFloor
+  _ -> e
+```
 
 </div><div>
 
@@ -599,16 +605,7 @@ This class defines an `Elevator` with methods to move up, move down, and go to a
 
 ### Pipe operator
 
-```unison
-Elevator 0 10
-  |> goToFloor 5
-  |> moveUp
-  |> moveDown
-```
-
-In Unison, the `|>` operator is used to pipe the result of one expression into the next as its argument. Each transformation is applied in sequence, allowing for a clear flow of data through inputs and outputs without intermediate variables.
-
-With intermediate variables, the same example would look like this:
+In Unison, we use __function composition__ to chain function calls together and advance the state of a program.
 
 ``` unison
 e0 = Elevator 0 10
@@ -617,9 +614,22 @@ e2 = moveUp e1
 e3 = moveUp e2
 ```
 
+Since the intermediate variables `e1`, `e2`, and `e3` are not needed, we often use the pipe operator `|>` to pass the result of one function directly into the next:
+
+```unison
+Elevator 0 10
+  |> goToFloor 5
+  |> moveUp
+  |> moveDown
+```
+
+Each transformation is applied in sequence, allowing for a clear flow of data through the inputs and outputs of functions.
+
 </div><div>
 
 ### Dot notation
+
+The dot notation in Python expresses method calls on an object which may _mutate_ the object's internal state.
 
 ```python
 e = Elevator()
@@ -628,7 +638,7 @@ e.move_up()
 e.move_down()
 ```
 
-In Python, dot notation is used to call methods on objects. Each method call can modify the object's internal state (mutating it in place) or return a new value.
+No arguments are passed to the methods because the `Elevator` instance `e` is implicitly passed as a reference to the methods via `self`.
 
 </div></div>
 
@@ -679,9 +689,18 @@ class Point(NamedTuple):
 
 The `@dataclass` decorator automatically generates special methods like `__init__()` and `__repr__()` for the class. `NamedTuple` creates an immutable class with similar benefits.
 
-## Inheritance
+</div></div>
 
-In Python, extending the behavior of a class can be accomplished via subclassing or __inheritance__.
+## Extending behavior
 
-All Unison types are __invariant__, meaning they cannot be subclassed or extended. However, you can define new types that contain other types.
+<div class="side-by-side"><div>
 
+### Generics and parametric polymorphism
+
+All Unison types are __invariant__, meaning they cannot be subclassed or extended. However, you can define new types that contain other types, or use __parametric polymorphism__ to create generic types and functions.
+
+</div><div>
+
+### Duck typing and inheritance
+
+</div></div>

--- a/src/compare-lang/unison-for-python-devs.md
+++ b/src/compare-lang/unison-for-python-devs.md
@@ -262,7 +262,6 @@ In Python, `None` is a singleton object representing the absence of a value at r
 
 </div></div>
 
-
 <div class="side-by-side"><div>
 
 ### Unit
@@ -284,7 +283,7 @@ Unison uses the `Unit` type, `()`, to represent a function that does not return 
 
 ```python
 def greet(name: str) -> None:
-  print "Hello " + name
+  print("Hello " + name)
 ```
 
 Python uses `None` as the type for functions that do not explicitly return something.
@@ -815,7 +814,7 @@ class RoboDuck:
   def quack(self): return "Electronic Quack!"
 
 quack_twice(Duck())
-quack_twice(RobotDuck())
+quack_twice(RoboDuck())
 ```
 
 Python uses __duck-typing__ to write functions or methods that operate on any object, which means that the expression `thing.quack` will succeed if the object a has a `quack` method, regardless of what it is.

--- a/src/compare-lang/unison-for-python-devs.md
+++ b/src/compare-lang/unison-for-python-devs.md
@@ -732,7 +732,7 @@ In Unison, __generic types__ allow you to write functions that can operate on an
 
 In the example above, `printTwice` is a function that takes two arguments: _a function_ that converts a value of any type `a` to `Text`, and a value of type `a`. Because `a` is used as the __type variable__ for both parameters, the same type must be used in both places when calling `printTwice`.
 
-In functional languages, we call this  __parametric polymorphism__.
+In functional languages, we call the ability to write functions that operate on types independently of their content __parametric polymorphism__.
 
 </div><div>
 
@@ -740,14 +740,14 @@ In functional languages, we call this  __parametric polymorphism__.
 
 ```python
 def quack_twice(thing):
-    thing.quack()
-    thing.quack()
+    print(thing.quack())
+    print(thing.quack())
 
 class Duck:
-    def quack(self): print("Quack!")
+    def quack(self): return "Quack!"
 
 class RoboDuck:
-    def quack(self): print("Electronic Quack!")
+    def quack(self): return "Electronic Quack!"
 
 quack_twice(Duck())
 quack_twice(RobotDuck())
@@ -756,5 +756,80 @@ quack_twice(RobotDuck())
 
 Python uses __duck-typing__ to write functions or methods that operate on any object, which means that the expression `thing.quack` will succeed if the object a has a `quack` method, regardless of what it is.
 
+</div></div>
+
+<div class="side-by-side"><div>
+
+### Algebraic data types
+
+Unison does not support inheritance or subtyping. All types are __invariant__. But you can use __algebraic data types__ to say that a particular type may be created in several different ways:
+
+```unison
+type Duck = AnimalDuck | RoboDuck Text | ToyDuck Text
+
+
+```
+
+The `type` declaration means that the `Duck` type has three _data constructors_. We might chose to have a regular "AnimalDuck" which does not have a special noise; the other two data constructors (`RoboDuck` and `ToyDuck`) take a `Text` argument representing the special behavior of that case (a quack prefix in this example).
+
+
+```unison
+Duck.toText : Duck -> Text
+Duck.toText d = match d with
+  AnimalDuck -> "Quack!"
+  RoboDuck prefix -> prefix ++ " Quack!"
+  ToyDuck prefix -> prefix ++ " Quack!"
+```
+
+The `Duck.toText` function uses __pattern matching__ on the data type to determine which kind duck it received and return the appropriate text.
+
+```
+quacks = do
+  printTwice Duck.toText Duck.AnimalDuck
+  printTwice Duck.toText (Duck.RoboDuck "Electronic")
+  printTwice Duck.toText (Duck.ToyDuck "Squeaky")
+```
+
+Our existing `printTwice` function would happily function with values of `Duck`, `RoboDuck`, and `ToyDuck` because they all are all of type `Duck`.
+
+</div><div>
+
+### Inheritance and Subtyping
+
+Let's say we wanted to use __inheritance__ to create different types of ducks that share a common interface for quacking:
+
+```python
+class Duck:
+    def quack(self) -> str:
+        return "Quack!"
+
+class AnimalDuck(Duck):
+    pass
+
+class RoboDuck(Duck):
+    def __init__(self, prefix: str):
+        self.prefix = prefix
+
+    def quack(self) -> str:
+        return f"{self.prefix} Quack!"
+
+class ToyDuck(Duck):
+    def __init__(self, prefix: str):
+        self.prefix = prefix
+
+    def quack(self) -> str:
+        return f"{self.prefix} Quack!"
+
+```
+
+In Python, classes can inherit from other classes, allowing for __subtyping__ and code reuse.
+
+```
+quack_twice(AnimalDuck())
+quack_twice(RoboDuck("Electronic"))
+quack_twice(ToyDuck("Squeaky"))
+```
+
+Our existing `quack_twice` function would happily function with instances of `AnimalDuck`, `RoboDuck`, and `ToyDuck` because they all share the same interface.
 </div></div>
 

--- a/src/compare-lang/unison-for-scala-devs.md
+++ b/src/compare-lang/unison-for-scala-devs.md
@@ -1,7 +1,7 @@
 ---
 layout: "compare-lang"
 title: "Unison for Scala devs"
-description: "Comparing structures and patterns between Unison and Scala"
+description: "Comparing syntax and patterns between Unison and Scala"
 ---
 
 [[toc]]
@@ -300,9 +300,19 @@ case class UserPreferences (preferences: List[String])
 
 ### Imports
 
-Unison uses the `use` keyword to import definitions while Scala uses the `import` keyword. Both Unison and Scala support imports at the top-level of the file and scoped to definitions.
-
 <div class="side-by-side"><div>
+
+Unison will attempt to match a function name to a definition without extra import statements based on the types of the arguments you provide.
+
+```unison
+foo.uniqueFunctionName : Nat -> Nat -> Nat
+foo.uniqueFunctionName a b = a + b
+
+bar.baz =
+  uniqueFunctionName 1 2
+```
+
+If there is any ambiguity, Unison will prompt you to disambiguate. You can use the `use` keyword to tell Unison which term you want to import.
 
 ```unison
 -- imports everything in the `models.User` namespace
@@ -313,6 +323,8 @@ use models User UserPreferences
 use models.User toJson fromJson
 ```
 
+The `use` keyword can also be used inside a function body for local scoping:
+
 ```unison
 sqrtplus1 : Float -> Float
 sqrtplus1 x =
@@ -320,9 +332,17 @@ sqrtplus1 x =
   sqrt x + 1.0
 ```
 
-</div>
+Or you can refer to the qualified name of a term, disambiguating it by adding namespace prefixes:
 
-<div>
+```unison
+sqrtplus1 : Float -> Float
+sqrtplus1 x =
+  Float.sqrt x + 1.0
+```
+
+</div><div>
+
+Scala uses the `import` keyword to bring code into scope.
 
 ```scala
 // imports everything in the `models` package.
@@ -332,6 +352,8 @@ import models.{User, UserPreferences}
 // Scala supports renaming imports, Unison does not.
 import models.UserPreferences as UPrefs
 ```
+
+Both Unison and Scala support imports at the top-level of the file and scoped to definitions.
 
 ```scala
 def sqrtplus1(x: Int) =

--- a/src/compare-lang/unison-for-scala-devs.md
+++ b/src/compare-lang/unison-for-scala-devs.md
@@ -12,7 +12,7 @@ description: "Comparing syntax and patterns between Unison and Scala"
 
 Unison variables can be defined at the top-level of a program. There is no keyword to introduce a value and all values are immutable.
 
-The type signature of a value or function appears _above_ the definition instead of interspersed with the names of the function parameters. Both Scala and Unison support type inference, so these type signatures are optional.
+The type signature of a value or function appears _above_ the definition instead of being interspersed with the names of the function parameters. Both Scala and Unison support type inference, so these type signatures are optional.
 
 ### Basic types
 
@@ -43,7 +43,7 @@ val aString : String = "A String value"
 val aChar : Char = 'a'
 ```
 
-In Scala, positive integers are created without the `+`. In Unison, `Nat` is the type for positive integers, all `Int` literals in Unison must include `+` or `-`.
+In Scala, positive integers are created without the `+`. In Unison, `Nat` is the type for positive integers. All `Int` literals in Unison must include `+` or `-`.
 
 </div></div>
 
@@ -147,7 +147,7 @@ During function application, arguments are separated by spaces:
 digits = splitDigitsOn ?| "abc12|def34|56|78"
 ```
 
-Since commas are not used to explicitly separate arguments, parenthesis disambiguate the order in which functions should be applied.
+Since commas are not used to explicitly separate arguments, parentheses disambiguate the order in which functions should be applied.
 
 </div><div>
 
@@ -365,7 +365,7 @@ def sqrtplus1(x: Int) =
 
 ## Comments and docs
 
-Unison comments _are not persisted_ to the Unison codebase. To save a note to your future self or colleagues, use a string literal or use a Unison `Doc` expression.
+Unison comments _are not persisted_ in the Unison codebase. To save a note to your future self or colleagues, use a string literal or use a Unison `Doc` expression.
 
 <div class="side-by-side"><div>
 
@@ -432,14 +432,14 @@ myTerm =
 
 {% endraw %}
 
-If a Doc element is created above a term or type, it will automatically share the name of the term or type suffixed with `.doc` .
+If a Doc element is created above a term or type, it will automatically share the name of the term or type suffixed with `.doc`.
 
 </div><div>
 
 ```scala
 /** A Scala Doc for the term below.
 
-With annotations it can automatically update some
+With annotations, it can automatically update some
 information about its inputs and outputs.
 
 It cannot run live snippets of the code it describes.
@@ -468,7 +468,7 @@ up = Direction.Up
 
 The `type` keyword introduces a new type. Its **data constructors** are separated by `|` on the right of the equals sign.
 
-Think of data constructors as functions which produce values of the given type.
+Think of data constructors as functions that produce values of the given type.
 
 ```unison
 -- the Floor type has one data constructor,
@@ -575,7 +575,7 @@ In Scala, you can add a trait and say that the existing `Floor` case class is a 
 | Subtyping                               | No.                                                                         | Yes.                                                                                    |
 | Record types                            | Yes. Single data constructor types with named fields.                       | Yes. Case classes                                                                       |
 | Typeclasses                             | No.                                                                         | Yes. Typeclasses via traits and implicit / given syntax.                                |
-| GADTs                                   | No.                                                                         | Yes. GADT’s via sealed traits and case classes                                          |
+| GADTs                                   | No.                                                                         | Yes. GADTs via sealed traits and case classes                                          |
 | Higher-kinded types                     | Yes. But in the absence of typeclasses, less common.                        | Yes.                                                                                    |
 | Type aliases                            | No.                                                                         | Yes.                                                                                    |
 


### PR DESCRIPTION
First pass at adding a Unison for Python devs language guide. We needed something for folks from different programming language paradigms. 

* A subsequent deployment will be needed to link it to the sidebar
* Minor changes in the Scala language guide for optional import rules

