### PR TITLE
Adds Java language guide

### DIFF
--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -1286,7 +1286,7 @@ callUnsafeDiv x y = do
   result
 ```
 
-The "type" of the exception is less important in Unison than in Java, since the thing that appears in the type signature is just `Exception`, but you can raise and catch exceptions that contain different types, communicating different failure modes.
+The "type" of the exception is less important in Unison than in Java, since the thing that appears in the type signature is just `Exception`, but you can raise and catch exceptions that contain different types, like our `ArithmeticException`, communicating different failure modes.
 
 </div><div>
 
@@ -1327,7 +1327,7 @@ Java distinguishes recoverable exceptions from unchecked exceptions, which do no
 
 <div class="side-by-side"><div>
 
-The entry point to a Unison program can be any delayed computation which may perform the `IO` and `Exception` effects, `'{IO, Exception} r`. The `IO` ability indicates that the function might use `IO` operations, and the `Exception` ability indicates that it may raise exceptions.
+The entry point to a Unison program can be any delayed computation which may perform the `IO` and `Exception` effects, `'{IO, Exception} t`. The `IO` ability indicates that the function might use `IO` operations, and the `Exception` ability indicates that it may raise exceptions.
 
 ```unison
 main : '{IO, Exception} ()

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -259,7 +259,7 @@ List.filter (n -> n % 2 === 0) [1, 2, 3, 4]
 -- Sum up a list
 List.foldLeft (acc n -> acc + n) 0 [1, 2, 3, 4]
 -- 10
-``f`
+```
 
 This style avoids explicit indexing and mutation. Iteration is __declarative__: you say what to do with each element, not how to step through the collection.
 
@@ -362,13 +362,17 @@ noneValue : Optional Nat
 noneValue = None
 ```
 
-Optional values _must be unwrapped_ to access the value contained in them. We use functions like `Optional.map`, `Optional.fold`, or pattern matching to transform or handle the absence of a value.
+Optional values _must be unwrapped_ to access the value contained in them. We use functions like `Optional.map`, `Optional.getOrElse`, or pattern matching to transform or handle the absence of a value.
 
 ```unison
 opt: Optional Text
 opt = Some "value"
 
 Optional.map (str -> Debug.trace "Got value:" str) opt
+
+-- Using `getOrElse` to provide a default if `opt` is `None`
+Optional.map (str -> str ++ "!!") opt
+  |> Optional.getOrElse "default"
 ```
 
 </div><div>
@@ -387,10 +391,14 @@ Java 8 introduced the `Optional` class:
 ```java
 Optional<String> opt = Optional.of("some value");
 
+// void operations require a different method
 opt.ifPresent(str -> System.out.println(str));
+
+// Using `orElse` to provide a default if `opt` is empty
+opt.map(str -> str + "!!").orElse("default");
 ```
 
-The `ifPresent` method is similar to `Optional.map` in Unison.
+Many of the methods in the `Optional` class are similar to those in Unison's `Optional` type.
 
 </div></div>
 

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -518,6 +518,33 @@ public class Main {
 
 </div></div>
 
+## First-class functions
+
+<div class="side-by-side"><div>
+
+In Unison, functions are **first-class citizens**, meaning they can be passed as arguments to other functions, returned from functions, and assigned to variables.
+
+In a signature, the function type is written as `(i -> o)`, with parentheses to indicate the argument is a function.
+
+```unison
+applyTwice : (a -> a) -> a -> a
+applyTwice f x =
+  (f (f x))
+```
+
+</div><div>
+
+In Java, functions are not first-class citizens. You can pass a `Function <A, B>` object as an argument to a method; however, in Java, you might employ a different pattern for code reuse, such as passing objects that implement a specific interface.
+
+```java
+import java.util.function.Function;
+public static <A> A applyTwice(Function<A, A> f, A x) {
+    return f.apply(f.apply(x));
+}
+```
+
+</div></div>
+
 # Data modeling
 
 An in-depth guide to the differences in data modeling between functional languages like Unison and object-oriented languages like Java is out of scope for now, but here are some high-level differences.
@@ -626,7 +653,6 @@ JsonValue aJsonArrayValue = aJsonArray; // Upcast to JsonValue
 
 </div></div>
 
-
 ## Record types
 
 <div class="side-by-side"><div>
@@ -693,7 +719,7 @@ public class Point {
 
 </div></div>
 
-# Generics
+## Generics
 
 <div class="side-by-side"><div>
 
@@ -712,6 +738,8 @@ Box.prettyPrint : Box a -> (a -> Text) -> Text
 Box.prettyPrint box toStringFunc =
   "Box(" ++ toStringFunc (Box.value box) ++ ")"
 ```
+
+All types in Unison are invariant; so concepts like type bounds do not apply.
 
 ```unison
 -- Type `Box Boolean` is inferred
@@ -751,10 +779,12 @@ public <T> String prettyPrint(Box<T> box, Function<T, String> toStringFunc) {
 }
 ```
 
+Because Java supports more complex type hierarchies than Unison, Java code might employ wildcard types like `<?>` or bounded type parameters like `<T extends Number>`. These concepts do not have direct equivalents in Unison.
+
 ```java
 // Type Box<Boolean> is inferred with diamond operator <>
 boolBox = new Box<>(true);
-natBox = new Box<Int>(42);
+intBox = new Box<Int>(42);
 prettyPrint(boolBox, Object::toString);
 ```
 

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -6,7 +6,7 @@ description: "Comparing syntax and patterns between Unison and Java"
 
 [[toc]]
 
-# Variables and basic types
+# Variables and basic expressions
 
 <div class="side-by-side"><div>
 
@@ -177,5 +177,114 @@ Attempting to modify an immutable collection will throw an `UnsupportedOperation
 List<Integer> aList = List.of(1, 2, 3, 4, 5);
 aList.add(6); // Throws UnsupportedOperationException
 ```
+
+</div></div>
+
+### Iterating over collections
+
+<div class="side-by-side"><div>
+
+In Unison, iteration is expressed through **higher-order functions** like `map`, `filter`, and `fold`. Instead of writing loops, you pass a function that describes how to transform or combine elements.
+
+```unison
+-- Double every number
+List.map (n -> n * 2) [1, 2, 3]
+-- [2, 4, 6]
+
+-- Keep only even numbers
+List.filter (n -> n % 2 == 0) [1, 2, 3, 4]
+-- [2, 4]
+
+-- Sum up a list
+List.foldLeft (acc n -> acc + n) 0 [1, 2, 3, 4]
+-- 10
+```
+
+This style avoids explicit indexing and mutation. Iteration is __declarative__: you say what to do with each element, not how to step through the collection.
+
+
+
+</div><div>
+
+In Java, the traditional approach uses the `Iterable` pattern, either with an __explicit loop__ or an enhanced for-loop:
+
+```
+List<Integer> numbers = List.of(1, 2, 3, 4, 5);
+
+for (int i = 0; i < numbers.size(); i++) {
+    int n = numbers.get(i);
+    System.out.println(n * 2);
+}
+
+for (int n : numbers) {
+    System.out.println(n * 2);
+}
+```
+
+Here, iteration is __imperative__: you describe how to step through each element and also describe the transformation to apply.
+
+```java
+List<Integer> doubled =
+    numbers.stream()
+           .map(n -> n * 2)
+           .toList();
+
+List<Integer> evens =
+    numbers.stream()
+           .filter(n -> n % 2 == 0)
+           .toList();
+
+int sum =
+    numbers.stream()
+           .reduce(0, (acc, n) -> acc + n);
+```
+
+Since Java 8, collections also support lambdas and streams, which bring them closer to Unison’s functional style.
+
+</div></div>
+
+### Lambdas
+
+<div class="side-by-side"><div>
+
+The argument surrounded by parentheses is an anonymous function (or lambda).
+
+```unison
+List.foldLeft (acc n -> acc + n) 0 [1, 2, 3, 4]
+```
+
+The function above takes two arguments: `acc` (the accumulator) and `n` (the current element). The function body is to the right of the `->`.
+
+```unison
+List.map (n -> let
+  doubled = n * 2
+  Debug.trace "Processing" (Nat.toText n)
+  doubled
+) [1, 2, 3]
+```
+
+The function body can be a single expression or a block of expressions using `let` and whitespace to delimit them.
+
+</div><div>
+
+```java
+int sum =
+    numbers.stream()
+           .reduce(0, (acc, n) -> acc + n);
+```
+
+Java 8's lambda syntax is similar to Unison's, but multiple arguments are separated by commas within parentheses.
+
+```java
+numbers.stream()
+       .map(n -> {
+           int doubled = n * 2;
+           System.out.println("Processing " + n);
+           return doubled;
+       })
+       .toList();
+```
+
+Curly braces `{}` are used to define a block of statements, and `return` is required to return a value from the block.
 
 </div></div>

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -439,7 +439,7 @@ int result3 = MathUtils.add(MathUtils.sum(List.of(1, 2)), 3);
 
 <div class="side-by-side"><div>
 
-## Namespaced functions
+## Functions
 
 Functions are standalone terms, defined at the top level of a program, within **namespaces**, or within other functions. Instead of mutating the state of an instance of a class, functions accept the values that they operate on, describe some behavior or transformation, and then return new values.
 
@@ -461,7 +461,7 @@ The functions above are defined in the `Greeter` namespace, delimited by the dot
 
 </div><div>
 
-## Class methods
+## Methods
 
 Java uses **classes** to _encapsulate data and behavior_. **Methods** belong to a class, and describe the set of behaviors that an instance of the class may perform.
 
@@ -790,6 +790,47 @@ prettyPrint(boolBox, Object::toString);
 
 </div></div>
 
+## Interfaces and behavioral abstraction
+
+<div class="side-by-side"><div>
+
+Unison's approach to behavioral abstraction is through **higher-order functions** and **abilities**, though abilities have more uses than just defining a contract for behavior.
+
+
+```unison
+Drawable.draw : Shape -> '{IO, Exception} ()
+
+type Shape
+  = Circle { radius : Float }
+  | Square { side : Float }
+```
+
+
+
+</div><div>
+
+Java uses **interfaces**, abstract classes, and basic inheritance to define contracts that classes can implement, allowing for polymorphism and code reuse.
+
+```java
+interface Drawable {
+    void draw();
+}
+
+class Circle implements Drawable {
+    public void draw() {
+        // Draw a circle
+    }
+}
+
+class Square implements Drawable {
+    public void draw() {
+        // Draw a square
+    }
+}
+```
+
+</div></div>
+
 # Control flow
 
 ## Conditionals
@@ -894,11 +935,69 @@ Switch statements _do not need to be exhaustive_, so if a value does not match a
 
 </div></div>
 
+### Decomposing values
+
+<div class="side-by-side"><div>
+
+In Unison, we use structural pattern matching to decompose values, extracting fields from data types, and matching on specific variants of a type.
+
+```unison
+type Shape = Circle Float | Square Float | Rectangle Float Float
+
+area : Shape -> Float
+area shape =
+  match shape with
+    Circle r -> 3.14 * r * r
+    Square s -> s * s
+    Rectangle w h -> w * h
+```
+
+Since there's no `.radius` method on `Circle` or no `.side` method on `Square`, pattern matching is one of the primary ways we access the values contained in a data type.
+
+</div><div>
+
+Newer Java 17+ versions support pattern matching on `sealed` interfaces in `switch` statements:
+
+```java
+sealed interface Shape permits Circle, Square, Rectangle { }
+
+record Circle(double radius) implements Shape { }
+record Square(double side) implements Shape { }
+record Rectangle(double width, double height) implements Shape { }
+
+// inside some class
+static double area(Shape shape) {
+        return switch (shape) {
+            case Circle c -> Math.PI * c.radius() * c.radius();
+            case Square s -> s.side() * s.side();
+            case Rectangle r -> r.width() * r.height();
+        };
+    }
+```
+
+In older Java versions, you might employ `instanceOf` checks in `if/else` statements to achieve similar behavior:
+
+```java
+static double area(Shape shape) {
+    if (shape instanceof Circle c) {
+        return Math.PI * c.radius() * c.radius();
+    } else if (shape instanceof Square s) {
+        return s.side() * s.side();
+    } else if (shape instanceof Rectangle r) {
+        return r.width() * r.height();
+    } else {
+        throw new IllegalArgumentException("Unknown shape: " + shape);
+    }
+}
+```
+
+</div></div>
+
 ### Pattern guards
 
 <div class="side-by-side"><div>
 
-In Unison, pattern matching can include guards, which are additional boolean conditions following `|` in the pattern that must be satisfied for a pattern to match.
+Pattern matching can include guards, which are additional boolean conditions following `|` in the pattern that must be satisfied for a pattern to match.
 
 ```unison
 grade : Nat -> Text

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -425,6 +425,7 @@ result2 = Nat.sum [1, 2, 3, 4, 5]
 result3 = Nat.add (Nat.sum [1, 2]) 3
 ```
 
+
 </div><div>
 
 In Java, method arguments are separated by commas within parentheses.
@@ -437,38 +438,34 @@ int result3 = MathUtils.add(MathUtils.sum(List.of(1, 2)), 3);
 
 </div></div>
 
-## Encapsulation and function composition
-
 <div class="side-by-side"><div>
 
-Functions are standalone terms, defined at the top level of a file or within other functions. Instead of mutating the state of an instance of a class, functions accept the values that they operate on, describe some behavior or transformation, and then return new values.
+## Namespaced functions
+
+Functions are standalone terms, defined at the top level of a program, within **namespaces**, or within other functions. Instead of mutating the state of an instance of a class, functions accept the values that they operate on, describe some behavior or transformation, and then return new values.
 
 ```unison
-greeter.getName : '{IO, Exception} Text
-greeter.getName = do
+Greeter.getName : '{IO, Exception} Text
+Greeter.getName = do
   printLine "What is your name?"
   name = readLine()
 
-greeter.greet : Text -> '{IO, Exception} ()
-greeter.greet name = do
+Greeter.greet : Text -> '{IO, Exception} ()
+Greeter.greet name = do
   if Text.isEmpty name then
     printLine "Hello, stranger!"
   else
     printLine ("Hello, " ++ name ++ "!")
 ```
 
-```unison
-main : '{IO, Exception} ()
-main = do
-  name = greeter.getName()
-  greeter.greet name
-```
+The functions above are defined in the `Greeter` namespace, delimited by the dot prefix in the function name. **Namespacing** helps organize related functions together, but does not imply any state or behavior is shared between them.
 
-A program is built by chaining together, or _composing_, the inputs and outputs of many functions.
 
 </div><div>
 
-Java uses classes to _encapsulate data and behavior_. Methods belong to a class, and can access or modify the data enclosed in it. They describe the set of behaviors that an instance of the class may perform.
+## Class methods
+
+Java uses **classes** to _encapsulate data and behavior_. **Methods** belong to a class, and describe the set of behaviors that an instance of the class may perform.
 
 ```java
 import java.util.Scanner;
@@ -492,7 +489,24 @@ public class Greeter {
 }
 ```
 
-In Java programs, you create instances of classes and invoke methods on them, changing their internal state and performing actions.
+</div></div>
+
+<div class="side-by-side"><div>
+
+Despite looking similar to Java method calls, due to the `Greeter.` prefix, when calling the `Greeter.greet` function in Unison, we explicitly pass in the `name` value that it operates on.
+
+```unison
+main : '{IO, Exception} ()
+main = do
+  name = Greeter.getName()
+  Greeter.greet name
+```
+
+A program is built by chaining together, or _composing_, the inputs and outputs of many functions.
+
+</div><div>
+
+In Java programs, you create instances of classes and invoke methods on them, changing the state of the object or performing actions based on that state.
 
 ```java
 public class Main {
@@ -505,6 +519,7 @@ public class Main {
 ```
 
 </div></div>
+
 
 # Data modeling
 

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -838,7 +838,7 @@ Unison has **record types** for modeling immutable single-constructor types with
 type Point = {
   x : Int,
   y : Int
-  }
+}
 ```
 
 Defining a record type in Unison automatically creates get, set, and modify functions for each field.

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -109,7 +109,7 @@ Since Java 10, local variables can use `var` for type inference, but the method 
 
 </div></div>
 
-### Access modifiers
+## Access modifiers
 
 <div class="side-by-side"><div>
 
@@ -368,6 +368,47 @@ The `ifPresent` method is similar to `Optional.map` in Unison.
 
 </div></div>
 
+## Delayed computations
+
+<div class="side-by-side"><div>
+
+In Unison, **delayed computations** are used to represent computations that are not executed until their result is needed. Think of delayed computations as zero argument functions, `() -> r`. In type signatures, they are represented with the syntactic sugar `'r`.
+
+```unison
+delayedVal : 'Nat
+delayedVal = do
+  -- No debug output yet
+  Debug.trace "Computing value" ()
+  42
+```
+
+The `do` keyword is used to introduce a delayed computation block.
+To call a delayed computation, use the `()` syntax.
+
+```unison
+-- The debug line will not appear until we call the thunk
+result = delayedVal()
+```
+
+</div><div>
+
+Java does not have built-in support for delayed computations. However, you can achieve similar behavior using the `Supplier<T>` interface, which represents a "supplier" of results, taking no arguments and returning a value of type `T`.
+
+```java
+Supplier<Integer> delayedVal = () -> {
+    System.out.println("Computing value");
+    return 42;
+};
+```
+
+Call the supplier with `.get()`:
+
+```java
+int result = delayedVal.get();
+```
+
+</div></div>
+
 # Method and function syntax
 
 <div class="side-by-side"><div>
@@ -553,7 +594,7 @@ An in-depth guide to the differences in data modeling between functional languag
 
 ## Data types
 
-Unison does not have classes, so there are no instance methods, no instance variables, no `new` constructor keyword, and no `this` keyword. Instead, we use **data types** to model how data is structured and **functions** to model behavior.
+Unison does not have classes, so there are no methods, no instance variables, no `new` constructor keyword, and no `this` keyword. Instead, we use **data types** to model how data is structured and **functions** that transform them to model behavior.
 
 A type can represent data with multiple variants (when a type can be created in one way or another) and data with multiple fields (when a type has several attributes), often in combination. Here's a simple example of a data type representing JSON values:
 
@@ -805,8 +846,6 @@ type Shape
   | Square { side : Float }
 ```
 
-
-
 </div><div>
 
 Java uses **interfaces**, abstract classes, and basic inheritance to define contracts that classes can implement, allowing for polymorphism and code reuse.
@@ -935,11 +974,11 @@ Switch statements _do not need to be exhaustive_, so if a value does not match a
 
 </div></div>
 
-### Decomposing values
+### Decomposing types
 
 <div class="side-by-side"><div>
 
-In Unison, we use structural pattern matching to decompose values, extracting fields from data types, and matching on specific variants of a type.
+In Unison, we use structural pattern matching to decompose types into their data constructors, extracting fields and matching on specific variants of a type.
 
 ```unison
 type Shape = Circle Float | Square Float | Rectangle Float Float
@@ -1070,7 +1109,7 @@ callUnsafeDiv x y = do
   result
 ```
 
-The "type" of the exception is less important in Unison than in Java, since the thing that appears in the type signature is just `Exception`, but you can raise and catch exceptions of different types, communicating different failure modes.
+The "type" of the exception is less important in Unison than in Java, since the thing that appears in the type signature is just `Exception`, but you can raise and catch exceptions which contain different types, communicating different failure modes.
 
 </div><div>
 
@@ -1104,5 +1143,45 @@ public void propagateException(int x, int y) throws ArithmeticException {
 ```
 
 Java distinguishes recoverable exceptions from unchecked exceptions, which do not need to be declared or caught. Unison does not make this distinction; all exceptions are treated the same way.
+
+</div></div>
+
+# Running programs
+
+<div class="side-by-side"><div>
+
+The entry point to a Unison program can be any delayed computation, `'r`, which may perform `IO` and `Exception` effects, `'{IO, Exception} r`. The `IO` ability indicates that the function performs input/output operations, and the `Exception` ability indicates that it may raise exceptions.
+
+```unison
+main : '{IO, Exception} ()
+main = do
+  printLine "Hello, Unison!"
+
+mainWithArgs : '{IO, Exception} ()
+mainWithArgs = do
+  args = getArgs()
+  printLine ("Arguments: " ++ Text.join args)
+
+mainException : '{Exception} ()
+mainException = do
+  safeDiv 10 0
+
+mainPure : 'Nat
+mainPure = do 42
+```
+
+All of the above are valid entry points to a Unison program. The function name is not special; you can name it anything you like.
+
+</div><div>
+
+In Java, the entry point to a program is the `main` method, which must be declared as `public static void main(String[] args)` within a class. The `String[] args` parameter allows command-line arguments to be passed to the program.
+
+```java
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello, Java!");
+    }
+}
+```
 
 </div></div>

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -309,8 +309,8 @@ Since Java 8, collections also support lambdas and streams, which bring them clo
 <div class="side-by-side"><div>
 
 ```unison
-List.takeWhile(n -> n < 4) [1, 2, 3, 4, 5]
-  |> List.filter(n -> not (n % 2 === 0))
+List.takeWhile(n -> n < 4) [1, 2, 3, 4, 5] -- Take numbers until we see a 4
+  |> List.filter(n -> not (n % 2 === 0)) -- Only keep odd numbers
 -- [1, 3]
 ```
 
@@ -321,10 +321,10 @@ In Unison, short-circuiting constructs like `break` and `continue` do not exist.
 ```java
 for (int n : numbers) {
     if (n > 4) {
-        break; // Exit the loop early
+        break;
     }
     if (n % 2 == 0) {
-        continue; // Skip even numbers
+        continue;
     }
     System.out.println(n);
     // Output: 1, 3

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -6,7 +6,7 @@ description: "Comparing syntax and patterns between Unison and Java"
 
 [[toc]]
 
-## Variables and basic types
+# Variables and basic types
 
 <div class="side-by-side"><div>
 
@@ -43,7 +43,7 @@ int anInt = +123;
 boolean aBoolean = true || false;
 ```
 
-Java expects a semicolon at the end of each statement, Unison does not.
+Java expects a semicolon at the end of each statement.
 
 
 </div></div>
@@ -87,8 +87,6 @@ In Unison, you cannot reassign or update a variable in a program once it has bee
 
 </div><div>
 
-<div>
-
 ```java
 String aReassignment = "Initial value";
 aReassignment = "New value"; // ok
@@ -103,6 +101,81 @@ final String constantValue = "I cannot be changed";
 private String privateValue = "Accessible only within this class";
 protected String protectedValue = "Package and subclasses";
 public String publicValue = "Accessible from anywhere";
+```
+
+</div></div>
+
+## Collections
+
+<div class="side-by-side"><div>
+
+There are no interfaces for collections in Unison. Our standard library provides a variety of distinct collection types, like `List`, `Set`, and `Map`, and more specialized collections like `NonEmptyList` and `NatMap`.
+
+```unison
+aList : List Nat
+aList = [1, 2, 3, 4, 5]
+
+aSet : Set Text
+aSet = Set.fromList ["🍎", "🍌", "🍒"]
+
+aMap : Map Text Int
+aMap = Map.fromList [("📘", +2), ("📙", -4), ("📔", +3)]
+```
+
+Collections in Unison are **immutable** by default.
+
+</div><div>
+
+Java Collections are arranged in a hierarchy, with interfaces like `List`, `Set`, and `Map` which define basic operations for common data structures, and classes like `ArrayList`, `HashSet`, and `HashMap` to instantiate them.
+
+```java
+List<Integer> aList = List.of(1, 2, 3, 4, 5);
+
+Set<String> aSet = Set.of("🍎", "🍌", "🍒");
+
+Map<String, Integer> aMap = Map.of("📘", 2, "📙", -4, "📔", 3);
+```
+
+Java collections are **mutable** by default, but you can create immutable collections using factory methods like these from the `List`, `Set`, and `Map` interfaces.
+
+</div></div>
+
+### Modifying collections
+
+<div class="side-by-side"><div>
+
+If you're coming from a Java background, you might be used to modifying collections in place. In Unison, since collections are immutable, you create copies of the original with the desired changes.
+
+```unison
+map1 = Map.fromList [("📘", +2), ("📙", -4), ("📔", +3)]
+map2 = Map.insert "📗" +5 map1
+map3 = Map.delete "📙" map2
+```
+Because the outputs to the modification functions return new maps, you can chain them together with the `|>` operator instead of creating intermediate variables:
+
+```unison
+map3 = Map.fromList [("📘", +2), ("📙", -4), ("📔", +3)]
+  |> Map.insert "📗" +5
+  |> Map.delete "📙"
+```
+</div><div>
+
+In Java, you can modify collections in place if they are mutable.
+
+```java
+Map<String, Integer> map1 = new HashMap<>();
+map1.put("📘", 2);
+map1.put("📙", -4);
+map1.put("📔", +3);
+map1.put("📗", +5);
+map1.remove("📙");
+```
+
+Attempting to modify an immutable collection will throw an `UnsupportedOperationException`.
+
+```java
+List<Integer> aList = List.of(1, 2, 3, 4, 5);
+aList.add(6); // Throws UnsupportedOperationException
 ```
 
 </div></div>

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -46,7 +46,7 @@ Java uses `//` for single-line comments and `/* ... */` for multi-line comments.
 
 <div class="side-by-side"><div>
 
-Unison variables are immutable values that can be defined at the top level of the program or within functions. Type signatures are located above the variable name, but are optional.
+Unison variables are immutable values that can be defined at the top-level of the program or within functions. Type signatures are located above the variable name, but are optional.
 
 ```unison
 aText : Text
@@ -93,7 +93,7 @@ exampleFunction =
   newValue
 ```
 
-Unison's type inference means you don't need to specify the type of `localValue` or the top level function `exampleFunction`.
+Unison's type inference means you don't need to specify the type of `localValue` or the top-level function `exampleFunction`.
 
 </div><div>
 
@@ -508,7 +508,7 @@ int result3 = MathUtils.add(MathUtils.sum(List.of(1, 2)), 3);
 
 ## Functions
 
-Functions are standalone terms, defined at the top level of a program, within **namespaces**, or within other functions. Instead of mutating the state of an instance of a class, functions accept the values that they operate on, describe some behavior or transformation, and then return new values.
+Functions are standalone terms, defined at the top-level of a program, within **namespaces**, or within other functions. Instead of mutating the state of an instance of a class, functions accept the values that they operate on, describe some behavior or transformation, and then return new values.
 
 ```unison
 Greeter.getName : '{IO, Exception} Text
@@ -675,7 +675,7 @@ abstract class JsonValue {
 }
 ```
 
-Each Json type might be implemented as a subclass which implements the `toJson` method to handle its specific serialization logic:
+Each JSON type might be implemented as a subclass that implements the `toJson` method to handle its specific serialization logic:
 
 ```java
 class JsonBoolean extends JsonValue {
@@ -722,7 +722,7 @@ JsonValue aJsonArrayValue = aJsonArray; // Upcast to JsonValue
 
 <div class="side-by-side"><div>
 
-Unison has **record types** for modeling immutable single constructor types with named fields.
+Unison has **record types** for modeling immutable single-constructor types with named fields.
 
 ```unison
 type Point = {
@@ -804,7 +804,7 @@ Box.prettyPrint box toStringFunc =
   "Box(" ++ toStringFunc (Box.value box) ++ ")"
 ```
 
-All types in Unison are invariant; so concepts like type bounds do not apply.
+All types in Unison are invariant, so concepts like type bounds do not apply.
 
 ```unison
 -- Type `Box Boolean` is inferred
@@ -861,7 +861,7 @@ prettyPrint(boolBox, Object::toString);
 
 ### Abilities
 
-One approach to defining behavioral contracts in Unison is through **abilities**. Abilities are a way to describe a set of operations, typically ones which involve some kind of effect, without dictating how that contract must be fulfilled.
+One approach to defining behavioral contracts in Unison is through **abilities**. Abilities are a way to describe a set of operations, typically ones that involve some kind of effect, without dictating how that contract must be fulfilled.
 
 This is how we might define a simple logging ability in Unison. We don't care where the log messages go, just that we can capture a text value and log it.
 
@@ -878,7 +878,7 @@ initialize = do
   Logger.log "Initializing application"
 ```
 
-The functions that provide concrete behavior for an ability are called **handlers**. For now we won't dig into _how_ handlers work, but they typicially translate the operations of an ability into other abilities, like `IO` for console output, or transform them into pure values, like logging to a `List` in memory.
+The functions that provide concrete behavior for an ability are called **handlers**. For now, we won't dig into _how_ handlers work, but they typically translate the operations of an ability into other abilities, like `IO` for console output, or transform them into pure values, like logging to a `List` in memory.
 
 ```unison
 ConsoleLogger.logger : '{Logger} a -> {IO, Exception} a
@@ -888,7 +888,7 @@ ConsoleLogger.logger = cases
   pure -> pure
 ```
 
-To apply a handler, you pass it a codeblock or expression that uses the ability _as an argument_.
+To apply a handler, you pass it a code block or expression that uses the ability _as an argument_.
 
 ```unison
 main : '{IO, Exception} ()
@@ -934,7 +934,7 @@ public class Main {
 }
 ```
 
-One major difference between Unison's abilities and Java's interfaces is that an interface is ultimately instantiated as an _object_. Abilities are not objects that can be passed around, they're more like properties of functions that are tracked in the type system. Picture the ability as a `throws` clause in the Java function signature `public void initialize() throws Logger`.
+One major difference between Unison's abilities and Java's interfaces is that an interface is ultimately instantiated as an _object_. Abilities are not objects that can be passed around; they're more like properties of functions that are tracked in the type system. Picture the ability as a `throws` clause in the Java function signature `public void initialize() throws Logger`.
 
 </div></div>
 
@@ -944,7 +944,7 @@ One major difference between Unison's abilities and Java's interfaces is that an
 
 <div class="side-by-side"><div>
 
-In Unison, conditionals are expressions that control the flow of execution and return values. A conditional expression has three parts: the `if` condition which must be a `Boolean`, the `then` branch, and the `else` branch.
+In Unison, conditionals are expressions that control the flow of execution and return values. A conditional expression has three parts: the `if` condition, which must be a `Boolean`, the `then` branch, and the `else` branch.
 
 ```unison
 sign : Int -> Text
@@ -957,7 +957,7 @@ sign n =
     "zero"
 ```
 
-In Unison, you cannot have an `if` without an `else` branch. This will fail to compile and you cannot save it to your codebase:
+In Unison, you cannot have an `if` without an `else` branch. This will fail to compile, and you cannot save it to your codebase:
 
 ```unison
 nope : Nat -> Text
@@ -1036,7 +1036,7 @@ String cardSuit(int n) {
 }
 ```
 
-`default` is slightly different from Unison's `_` wildcard pattern, as a switch statement which does not contain explicit `return` statements or `break` statements will run the `default` case.
+`default` is slightly different from Unison's `_` wildcard pattern, as a switch statement that does not contain explicit `return` statements or `break` statements will run the `default` case.
 
 Switch statements _do not need to be exhaustive_, so if a value does not match any case and there is no `default`, the program simply continues after the switch block.
 
@@ -1143,7 +1143,7 @@ String grade(int score) {
 
 <div class="side-by-side"><div>
 
-In Unison, exceptions are an **ability** that work similarly to Java's checked exceptions. Functions that may throw exceptions must declare the `Exception` ability in their type signature, `{Exception}`.
+In Unison, exceptions are an **ability** that works similarly to Java's checked exceptions. Functions that may throw exceptions must declare the `Exception` ability in their type signature, `{Exception}`.
 
 ```unison
 safeDiv : Nat -> Nat -> {Exception} Nat
@@ -1154,7 +1154,7 @@ safeDiv x y =
   else x / y
 ```
 
-The calling function must handle the exception. One way to do this is by applying functions like `Exception.catch`, which translate the exception into a value of `Either` `Left`, representing a failure, or `Right`, enclosing the successful result:
+The calling function must handle the exception. One way to do this is by applying functions like `Exception.catch`, which translates the exception into a value of `Either` `Left`, representing a failure, or `Right`, enclosing the successful result:
 
 ```unison
 leftValue : Either Failure Nat
@@ -1177,11 +1177,11 @@ callUnsafeDiv x y = do
   result
 ```
 
-The "type" of the exception is less important in Unison than in Java, since the thing that appears in the type signature is just `Exception`, but you can raise and catch exceptions which contain different types, communicating different failure modes.
+The "type" of the exception is less important in Unison than in Java, since the thing that appears in the type signature is just `Exception`, but you can raise and catch exceptions that contain different types, communicating different failure modes.
 
 </div><div>
 
-In Java, exceptions are part of the language's error handling mechanism. Methods that may throw checked exceptions must declare them in their `throws` clause.
+In Java, exceptions are part of the language's error-handling mechanism. Methods that may throw checked exceptions must declare them in their `throws` clause.
 
 ```java
 public int safeDiv(int x, int y) throws ArithmeticException {

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -1,0 +1,108 @@
+---
+layout: "compare-lang"
+title: "Unison for Java devs"
+description: "Comparing syntax and patterns between Unison and Java"
+---
+
+[[toc]]
+
+## Variables and basic types
+
+<div class="side-by-side"><div>
+
+Unison variables are immutable values that can be defined at the top level of the program or within functions. Type signatures are located above the variable name, but are optional.
+
+```unison
+aText : Text
+aText = "Hello, world!"
+
+aChar : Char
+aChar = ?A
+
+aNat : Nat
+aNat = 123
+
+anInt : Int
+anInt = +123
+
+aBoolean : Boolean
+aBoolean = true || false
+```
+
+</div><div>
+
+Java variables are defined within classes or methods. Type signatures are found inline, with the type preceding the variable name.
+
+```java
+String aText = "Hello, world!";
+
+char aChar = 'A';
+
+int anInt = +123;
+
+boolean aBoolean = true || false;
+```
+
+Java expects a semicolon at the end of each statement, Unison does not.
+
+
+</div></div>
+
+<div class="side-by-side"><div>
+
+```unison
+exampleFunction =
+  localValue = 10
+  newValue = localValue + 5
+  newValue
+```
+
+Unison's type inference means you don't need to specify the type of `localValue` or the top level function `exampleFunction`.
+
+</div><div>
+
+```java
+int exampleMethod() {
+    var localVar = 10;
+    localVar += 5;
+    return localVar;
+}
+```
+
+Java(10+) local variables can use `var` for type inference, but the method return type must always be explicitly declared.
+
+</div></div>
+
+
+### Access modifiers
+
+<div class="side-by-side"><div>
+
+```unison
+noReassignments = "Initial value"
+noReassignments = "🚫 Will not compile, variable is ambiguous."
+```
+
+In Unison, you cannot reassign or update a variable in a program once it has been defined, so there is no `final` keyword. Variables are enclosed within functions to limit their scope. There are no private/public access modifiers in Unison.
+
+</div><div>
+
+<div>
+
+```java
+String aReassignment = "Initial value";
+aReassignment = "New value"; // ok
+```
+
+In Java, variables are mutable by default.
+
+Java has access modifiers like `final`, `private`, `protected`, and `public` to control variable mutability and visibility.
+
+```java
+final String constantValue = "I cannot be changed";
+private String privateValue = "Accessible only within this class";
+protected String protectedValue = "Package and subclasses";
+public String publicValue = "Accessible from anywhere";
+```
+
+</div></div>

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -1031,3 +1031,78 @@ String grade(int score) {
 ```
 
 </div></div>
+
+## Exception handling
+
+<div class="side-by-side"><div>
+
+In Unison, exceptions are an **ability** that work similarly to Java's checked exceptions. Functions that may throw exceptions must declare the `Exception` ability in their type signature, `{Exception}`.
+
+```unison
+safeDiv : Nat -> Nat -> {Exception} Nat
+safeDiv x y =
+  if y == 0 then
+    Exception.raiseFailure
+      (typeLink ArithmeticException) "Divide by zero" (x, y)
+  else x / y
+```
+
+The calling function must handle the exception. One way to do this is by applying functions like `Exception.catch`, which translate the exception into a value of `Either` `Left`, representing a failure, or `Right`, enclosing the successful result:
+
+```unison
+leftValue : Either Failure Nat
+leftValue = Exception.catch do safeDiv 10 0
+-- Returns: Left (Failure ArithmeticException "Divide by zero" (10, 0))
+
+rightValue : Either Failure Nat
+rightValue = Exception.catch do safeDiv 10 2
+-- Returns: Right 5
+```
+
+Or, the calling function can also propagate the exception by declaring the `Exception` ability in its own type signature:
+
+```unison
+callUnsafeDiv : Nat -> Nat -> '{Exception} Nat
+callUnsafeDiv x y = do
+  result = safeDiv x y
+  -- Might never reach here if an exception is raised
+  Debug.trace "Result is:" (Nat.toText result)
+  result
+```
+
+The "type" of the exception is less important in Unison than in Java, since the thing that appears in the type signature is just `Exception`, but you can raise and catch exceptions of different types, communicating different failure modes.
+
+</div><div>
+
+In Java, exceptions are part of the language's error handling mechanism. Methods that may throw checked exceptions must declare them in their `throws` clause.
+
+```java
+public int safeDiv(int x, int y) throws ArithmeticException {
+    if (y == 0) {
+        throw new ArithmeticException("Divide by zero");
+    }
+    return x / y;
+}
+```
+
+When calling a method that throws a checked exception, you must either handle the exception with a `try-catch` block or declare it in your own method's `throws` clause.
+
+```java
+public void callUnsafeDiv(int x, int y) {
+    try {
+        int result = safeDiv(x, y);
+        System.out.println("Result is: " + result);
+    } catch (ArithmeticException e) {
+        System.out.println("Error: " + e.getMessage());
+    }
+}
+
+public void propagateException(int x, int y) throws ArithmeticException {
+    int result = safeDiv(x, y);
+    System.out.println("Result is: " + result);
+}
+```
+
+Java distinguishes recoverable exceptions from unchecked exceptions, which do not need to be declared or caught. Unison does not make this distinction; all exceptions are treated the same way.
+
+</div></div>

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -113,29 +113,31 @@ Since Java 10, local variables can use `var` for type inference, but the method 
 
 <div class="side-by-side"><div>
 
+Unison does not have access modifier keywords that change the visibility of definitions. All definitions are public by default. Variables and functions are enclosed within other functions to limit their scope.
+
 ```unison
 noReassignments = "Initial value"
 noReassignments = "🚫 Will not compile, variable is ambiguous."
 ```
 
-In Unison, you cannot reassign or update a variable in a program once it has been defined, so there is no `final` keyword. Variables are enclosed within functions to limit their scope. There are no private/public access modifiers in Unison.
+You cannot reassign or update a variable in a program once it has been defined, so there are no keywords for controlling its scope, lifecycle, or mutability.
 
 </div><div>
 
-```java
-String aReassignment = "Initial value";
-aReassignment = "New value"; // ok
-```
-
-In Java, variables are mutable by default.
-
-Java has access modifiers like `final`, `private`, `protected`, and `public` to control mutability and visibility.
+Java has access modifiers like `final` or `public` to control mutability and visibility.
 
 ```java
 final String constantValue = "I cannot be changed";
 private String privateValue = "Accessible only within this class";
 protected String protectedValue = "Package and subclasses";
 public String publicValue = "Accessible from anywhere";
+```
+
+In Java, variables are mutable by default.
+
+```java
+String aReassignment = "Initial value";
+aReassignment = "New value"; // ok
 ```
 
 </div></div>
@@ -370,7 +372,6 @@ opt = Some "value"
 
 Optional.map (str -> Debug.trace "Got value:" str) opt
 
--- Using `getOrElse` to provide a default if `opt` is `None`
 Optional.map (str -> str ++ "!!") opt
   |> Optional.getOrElse "default"
 ```
@@ -394,7 +395,6 @@ Optional<String> opt = Optional.of("some value");
 // void operations require a different method
 opt.ifPresent(str -> System.out.println(str));
 
-// Using `orElse` to provide a default if `opt` is empty
 opt.map(str -> str + "!!").orElse("default");
 ```
 
@@ -467,7 +467,7 @@ Nat.sum ns =
 
 </div><div>
 
-Java is an object-oriented language, so **methods** that belong to classes are used to describe program behavior. Static methods can be called without creating an instance of a class, so let's use them to introduce basic syntax differences.
+Java is an object-oriented language, so **methods** that belong to classes are used to describe program behavior. Static methods can be called without creating an instance of a class. Let's use them to introduce basic syntax differences.
 
 ```java
 class MathUtils {
@@ -532,7 +532,7 @@ Greeter.greet name =
     printLine ("Hello, " ++ name ++ "!")
 ```
 
-The functions above are defined in the `Greeter` namespace, delimited by the dot prefix in the function name. **Namespacing** helps organize related functions together, but does not imply any state or behavior is shared between them.
+The functions above are defined in the `Greeter` namespace, delimited by the dot prefix in the function name. **Namespaces** help organize related functions together, similar to Java packages.
 
 </div><div>
 
@@ -540,7 +540,11 @@ The functions above are defined in the `Greeter` namespace, delimited by the dot
 
 Java uses **classes** to _encapsulate data and behavior_. **Methods** belong to a class, and describe the set of behaviors that an instance of the class may perform.
 
+Java packages, like `com.unison`, group related code together and prevent naming conflicts, with the caveat that Java packages are tied to the file system structure of the project.
+
 ```java
+package com.unison;
+
 import java.util.Scanner;
 
 public class Greeter {
@@ -582,6 +586,7 @@ A program is built by chaining together, or _composing_, the inputs and outputs 
 In Java programs, you create instances of classes and invoke methods on them, changing the state of the object or performing actions based on that state.
 
 ```java
+import com.unison.Greeter;
 public class Main {
   public static void main(String[] args) {
     Greeter greeter = new Greeter();
@@ -590,6 +595,69 @@ public class Main {
   }
 }
 ```
+
+</div></div>
+
+### Import statements
+
+<div class="side-by-side"><div>
+
+Unison differs from Java in that you do not, by default, need to import definitions from other namespaces to use them. If a definition exists in your current project and its name is unambiguous, you can use it directly.
+
+```unison
+namespace1.uniqueName : Nat -> Nat
+namespace1.uniqueName n = n + 1
+
+-- works without an import or namespace prefix
+namespace2.baz =
+  uniqueName 1
+```
+
+If you need to specify where a definition comes from, you can disambiguate by prefixing it with its namespace path.
+
+```unison
+namespace1.dupeName = 1 + 1
+namespace2.dupeName = 2 + 2
+
+useDupe = namespace2.dupeName + 1
+```
+
+The `use` keyword can bring multiple definitions from other namespaces into scope. You can import an entire namespace or specific terms.
+
+```unison
+{- Imports everything from the `namespace1`
+   namespace for use in the file -}
+use namespace1
+
+-- Only imports the foo definition from namespace1
+use namespace1 foo
+
+-- Imports both foo and bar from namespace1
+use namespace1 foo bar
+```
+</div><div>
+In Java, you must import classes from other packages to use them without their package prefix.
+
+```java
+package com.unison;
+
+public class Foo {
+    public static int uniqueName(int n) {
+        return n + 1;
+    }
+}
+```
+
+```java
+import com.unison.Foo;
+public class Bar {
+    public void baz() {
+        Foo.uniqueName(1);
+    }
+}
+```
+
+If two imported classes have the same name, you must use their fully qualified names to disambiguate them.
 
 </div></div>
 
@@ -609,7 +677,7 @@ applyTwice f x =
 
 </div><div>
 
-In Java, functions are not first-class citizens. You can pass a `Function <A, B>` object as an argument to a method; however, in Java, you might employ a different pattern for code reuse, such as passing objects that implement a specific interface.
+In Java, functions are not first-class citizens. You can pass a `Function <A, B>` object as an argument to a method; or you might employ a different pattern for code reuse, such as passing objects that implement a specific interface.
 
 ```java
 import java.util.function.Function;
@@ -620,9 +688,9 @@ public static <A> A applyTwice(Function<A, A> f, A x) {
 
 </div></div>
 
-# Data modeling
+# Types and data
 
-An in-depth guide to the differences in data modeling between functional languages like Unison and object-oriented languages like Java is out of scope for now, but here are some high-level differences.
+An in-depth guide to the differences in data modeling between functional languages like Unison and object-oriented languages like Java is out of scope for now, but here are some high-level comparison points.
 
 <div class="side-by-side"><div>
 
@@ -847,7 +915,7 @@ class Box<T> {
 In a method signature, generic type parameters are declared in angle brackets `< >` before the return type:
 
 ```java
-public <T> String prettyPrint(Box<T> box, Function<T, String> toStringFunc) {
+public static <T> String prettyPrint(Box<T> box, Function<T, String> toStringFunc) {
     return "Box(" + toStringFunc.apply(box.getValue()) + ")";
 }
 ```
@@ -855,10 +923,8 @@ public <T> String prettyPrint(Box<T> box, Function<T, String> toStringFunc) {
 Because Java supports more complex type hierarchies than Unison, Java code might employ wildcard types like `<?>` or bounded type parameters like `<T extends Number>`. These concepts do not have direct equivalents in Unison.
 
 ```java
-// Type Box<Boolean> is inferred with diamond operator <>
-boolBox = new Box<>(true);
-intBox = new Box<Int>(42);
-prettyPrint(boolBox, Object::toString);
+Box<Integer> intBox = new Box<Integer>(42);
+Box.prettyPrint(intBox, Object::toString);
 ```
 
 </div></div>
@@ -931,9 +997,8 @@ The `ConsoleLogger` class provides a concrete implementation of the `Logger` int
 
 ```java
 public class Main {
-
     // The Logger is accepted as a regular parameter
-    public void initialize(Logger logger) {
+    public static void initialize(Logger logger) {
         logger.log("Initializing application");
     }
 

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -69,7 +69,7 @@ int exampleMethod() {
 }
 ```
 
-Java(10+) local variables can use `var` for type inference, but the method return type must always be explicitly declared.
+Since Java 10, local variables can use `var` for type inference, but the method return type must always be explicitly declared.
 
 </div></div>
 
@@ -160,7 +160,7 @@ map3 = Map.fromList [("📘", +2), ("📙", -4), ("📔", +3)]
 ```
 </div><div>
 
-In Java, you can modify collections in place if they are mutable.
+In Java, it's common to modify mutable collections in place.
 
 ```java
 Map<String, Integer> map1 = new HashMap<>();
@@ -288,3 +288,188 @@ numbers.stream()
 Curly braces `{}` are used to define a block of statements, and `return` is required to return a value from the block.
 
 </div></div>
+
+## Nullability
+
+<div class="side-by-side"><div>
+
+In Unison, all values are **non-nullable** by default. This means you don't have to worry about null pointer exceptions. Instead, values that might be absent are represented by a type, called `Optional`.
+
+```unison
+someValue : Optional Nat
+someValue = Some 42
+
+noneValue : Optional Nat
+noneValue = None
+```
+
+Optional values _must be unwrapped_ to access the value contained in them. We use functions like `Optional.map`, `Optional.fold`, or pattern matching to transform or handle the absence of a value.
+
+```unison
+opt: Optional Text
+opt = Some "value"
+
+Optional.map (str -> Debug.trace "Got value:" str) opt
+```
+
+</div><div>
+
+In Java, you often have to check for **null** before using a value. Failure to do so can lead to `NullPointerException`s.
+
+```java
+Integer value = getValue();
+if (value != null) {
+    System.out.println(value);
+}
+```
+
+Java 8 introduced the `Optional` class:
+
+```java
+Optional<String> opt = Optional.of("some value");
+
+opt.ifPresent(str -> System.out.println(str));
+```
+
+The `ifPresent` method is similar to `Optional.map` in Unison.
+
+</div></div>
+
+# Method and function syntax
+
+<div class="side-by-side"><div>
+
+Unison is a functional language, so we use **functions** to describe program behavior. Here are some simple function examples:
+
+```unison
+Nat.add : Nat -> Nat -> Nat
+Nat.add x y = x + y
+
+Nat.sum : [Nat] -> Nat
+Nat.sum ns =
+  List.foldLeft (acc n -> acc + n) 0 ns
+```
+
+* Type signatures are located above the function name, not inline.
+* The return type of the function is the _last_ type to the right of the `->`.
+* Multiple parameters are delimited in the signature by `->`, not commas.
+* In the definition, parameters are listed after the function name, separated by spaces. The function body follows the `=`.
+* The function body is whitespace-delimited. Blocks of code are indented at the same level to represent lexical scope.
+* There is no explicit return statement; the value of the last expression in the function body is returned.
+
+</div><div>
+
+Java is an object-oriented language, so **methods** that belong to classes are used to describe program behavior. Static methods can be called without creating an instance of a class, so let's use them to introduce basic syntax differences.
+
+```java
+class MathUtils {
+    public static int add(int x, int y) {
+        return x + y;
+    }
+
+    public static int sum(List<Integer> ns) {
+        return ns.stream().reduce(0, (acc, n) -> acc + n);
+    }
+}
+```
+
+* Type signatures are inline, with the access modifier and return type preceding the method name.
+* Multiple parameters are delimited by commas within parentheses.
+* The function body is enclosed in curly braces `{}`.
+* An explicit `return` statement is required to return a value.
+
+</div></div>
+
+## Calling methods and functions
+
+<div class="side-by-side"><div>
+
+In Unison, functions are called without parentheses or commas separating their arguments. Parentheses are only needed to group expressions or clarify precedence.
+
+```unison
+result1 = Nat.add 2 3
+result2 = Nat.sum [1, 2, 3, 4, 5]
+result3 = Nat.add (Nat.sum [1, 2]) 3
+```
+
+</div><div>
+
+In Java, method arguments are separated by commas within parentheses.
+
+```java
+int result1 = MathUtils.add(2, 3);
+int result2 = MathUtils.sum(List.of(1, 2, 3, 4, 5));
+int result3 = MathUtils.add(MathUtils.sum(List.of(1, 2)), 3);
+```
+
+</div></div>
+
+## Encapsulation and function composition
+
+<div class="side-by-side"><div>
+
+Functions are standalone terms, defined at the top level of a file or within other functions. Instead of mutating the state of an instance of a class, functions accept the values that they operate on, describe some behavior or transformation, and then return new values.
+
+```unison
+greeter.getName : '{IO, Exception} Text
+greeter.getName = do
+  printLine "What is your name?"
+  name = readLine()
+
+greeter.greet : Text -> '{IO, Exception} ()
+greeter.greet name =
+  if Text.isEmpty name then
+    printLine "Hello, stranger!"
+  else
+    printLine ("Hello, " ++ name ++ "!")
+```
+
+```unison
+main : '{IO, Exception} ()
+main = do
+  name = greeter.getName()
+  greeter.greet name
+```
+
+A program is built by chaining together, or _composing_, the inputs and outputs of many functions.
+
+</div><div>
+
+Java uses classes to _encapsulate data and behavior_. Methods belong to a class, and can access or modify the data enclosed in it. They describe the set of behaviors that an instance of the class may perform.
+
+```java
+import java.util.Scanner;
+
+public class Greeter {
+    private String name;
+
+    public void getName() {
+        Scanner scanner = new Scanner(System.in);
+        System.out.println("What is your name?");
+        this.name = scanner.nextLine();
+    }
+
+    public void greet() {
+        if (this.name != null && !this.name.isEmpty()) {
+            System.out.println("Hello, " + this.name + "!");
+        } else {
+            System.out.println("Hello, stranger!");
+        }
+    }
+}
+```
+
+In Java programs, you create instances of classes and invoke methods on them:
+
+```java
+public class Main {
+  public static void main(String[] args) {
+    Greeter greeter = new Greeter();
+    greeter.getName();
+    greeter.greet();
+  }
+}
+```
+
+</div></div>
+

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -425,7 +425,6 @@ result2 = Nat.sum [1, 2, 3, 4, 5]
 result3 = Nat.add (Nat.sum [1, 2]) 3
 ```
 
-
 </div><div>
 
 In Java, method arguments are separated by commas within parentheses.
@@ -459,7 +458,6 @@ Greeter.greet name = do
 ```
 
 The functions above are defined in the `Greeter` namespace, delimited by the dot prefix in the function name. **Namespacing** helps organize related functions together, but does not imply any state or behavior is shared between them.
-
 
 </div><div>
 
@@ -519,7 +517,6 @@ public class Main {
 ```
 
 </div></div>
-
 
 # Data modeling
 
@@ -692,6 +689,73 @@ public class Point {
         return y;
     }
 }
+```
+
+</div></div>
+
+# Generics
+
+<div class="side-by-side"><div>
+
+In Unison, **type variables** are used to define generic functions and data types. Type variables are **lowercase letters** that stand in for any type.
+
+In a type definition, type variables are listed after the type name:
+
+```unison
+type Box a = { value : a }
+```
+
+In a function signature, you can refer to type variables without declaring them explicitly; they are inferred from their usage:
+
+```unison
+Box.prettyPrint : Box a -> (a -> Text) -> Text
+Box.prettyPrint box toStringFunc =
+  "Box(" ++ toStringFunc (Box.value box) ++ ")"
+```
+
+```unison
+-- Type `Box Boolean` is inferred
+boolBox = Box true
+
+natBox : Box Nat
+natBox = Box 42
+
+Box.prettyPrint boolBox Boolean.toText
+```
+
+Unison's type system does not erase generic type information at runtime.
+
+</div><div>
+
+Java supports **generics** to define classes, interfaces, and methods that operate on types later specified by the user. Generic type parameters are **uppercase letters** in `<>` brackets.
+
+```java
+class Box<T> {
+    private T value;
+
+    public Box(T value) {
+        this.value = value;
+    }
+
+    public T getValue() {
+        return value;
+    }
+}
+```
+
+In a method signature, generic type parameters are declared in angle brackets `< >` before the return type:
+
+```java
+public <T> String prettyPrint(Box<T> box, Function<T, String> toStringFunc) {
+    return "Box(" + toStringFunc.apply(box.getValue()) + ")";
+}
+```
+
+```java
+// Type Box<Boolean> is inferred with diamond operator <>
+boolBox = new Box<>(true);
+natBox = new Box<Int>(42);
+prettyPrint(boolBox, Object::toString);
 ```
 
 </div></div>

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -140,6 +140,32 @@ public String publicValue = "Accessible from anywhere";
 
 </div></div>
 
+## Void and Unit
+
+<div class="side-by-side"><div>
+
+All functions in Unison must return a value. But there are times when a function is called for some effect and there is no meaningful value to return. The value we use in these cases is `()` also known as `Unit`.
+
+```unison
+doSomething : ()
+doSomething =
+  Debug.trace "Doing something" ()
+  ()
+```
+
+</div><div>
+
+In Java, methods that do not return a value have the type `void`. There is no value of type `void`; it simply indicates the absence of something to return.
+
+```java
+void doSomething() {
+    // No meaningful value to return
+    System.out.println("Doing something");
+}
+```
+
+</div></div>
+
 ## Collections
 
 <div class="side-by-side"><div>
@@ -570,7 +596,7 @@ In a signature, the function type is written as `(i -> o)`, with parentheses to 
 ```unison
 applyTwice : (a -> a) -> a -> a
 applyTwice f x =
-  (f (f x))
+  f (f x)
 ```
 
 </div><div>
@@ -609,8 +635,6 @@ type JsonValue
 ```
 
 This `JsonValue` type can represent any JSON data structure. Each variant, or **data constructor**, is separated by `|`, and some variants (like `JsonArray` and `JsonObject`) contain a reference to the same type, allowing for nested structures.
-
-Functions can then be defined to operate on this data type, such as a function to serialize a `JsonValue` to a string:
 
 ```unison
 JsonValue.toJson : JsonValue -> Text
@@ -718,7 +742,7 @@ Point.y.modify : (Int ->{g} Int) -> Point ->{g} Point
 Point.y.set    : Int -> Point -> Point
 ```
 
-Althouth the dot notation in Unison's record types _looks similar_ to Java's mutable method calls, modifying a field _returns a new record with the updated value_, leaving the original unchanged.
+Although the dot notation in Unison's record types _looks similar_ to Java's mutable method calls, modifying a field _returns a new record with the updated value_, leaving the original unchanged.
 
 ```unison
 pointA : Point
@@ -837,7 +861,7 @@ prettyPrint(boolBox, Object::toString);
 
 ### Abilities
 
-One approach to defining behavioral contracts in Unison is through **abilities**, and if you're familiar with Java's interfaces, you have a good starting point for an intuition of what they do. Abilities are a way to describe a set of operations, typically ones which involve some kind of effect, without dictating how that contract must be fulfilled.
+One approach to defining behavioral contracts in Unison is through **abilities**. Abilities are a way to describe a set of operations, typically ones which involve some kind of effect, without dictating how that contract must be fulfilled.
 
 This is how we might define a simple logging ability in Unison. We don't care where the log messages go, just that we can capture a text value and log it.
 
@@ -846,8 +870,7 @@ ability Logger where
   log : Text -> ()
 ```
 
-In our application logic, we can use the general `Logger.log` operation. Abilities are tracked in the type system, a bit like checked exceptions in Java, so the `{Logger}` indicates that this function requires something that handles the `Logger` ability. The `{Logger}` ability requirement will appear in the type signatures of all the functions that call `Logger.log` until some bit of code provides a concrete implementation for it.
-
+In our application logic, we can use the general `Logger.log` operation. Abilities are tracked in the type system, a bit like checked exceptions in Java. The `{Logger}` indicates that this function requires something that handles the `Logger` ability or it will be passed up the call stack as a requirement until some bit of code provides an implementation for it.
 
 ``` unison
 initialize : '{Logger} ()
@@ -855,7 +878,7 @@ initialize = do
   Logger.log "Initializing application"
 ```
 
-The functions that provide concrete behavior for an ability are called **handlers**. For now we won't dig into _how_ handlers work; they provide the implementation for the operations specified in the ability.
+The functions that provide concrete behavior for an ability are called **handlers**. For now we won't dig into _how_ handlers work, but they typicially translate the operations of an ability into other abilities, like `IO` for console output, or transform them into pure values, like logging to a `List` in memory.
 
 ```unison
 ConsoleLogger.logger : '{Logger} a -> {IO, Exception} a
@@ -894,7 +917,7 @@ class ConsoleLogger implements Logger {
 }
 ```
 
-The `ConsoleLogger` class provides a concrete implementation of the `Logger` interface. You can then use the `Logger` interface as a type for variables, method parameters, or return types, allowing for polymorphism.
+The `ConsoleLogger` class provides a concrete implementation of the `Logger` interface. You can then use the `Logger` interface as a type for variables, method parameters, or return types.
 
 ```java
 public class Main {
@@ -905,13 +928,13 @@ public class Main {
     }
 
     public static void main(String[] args) {
-        Logger logger = new ConsoleLogger(); // Interface type pointing to a concrete implementation
+        Logger logger = new ConsoleLogger();
         initialize(logger);
     }
 }
 ```
 
-One major difference between Unison's abilities and Java's interfaces is that an interface is instantiated as an _object_. Abilities are not objects that can be passed around, they're effects that are tracked in the type system. Picture the ability as a `throws` clause in a Java function signature, like `public void initialize() throws Logger`.
+One major difference between Unison's abilities and Java's interfaces is that an interface is ultimately instantiated as an _object_. Abilities are not objects that can be passed around, they're more like properties of functions that are tracked in the type system. Picture the ability as a `throws` clause in the Java function signature `public void initialize() throws Logger`.
 
 </div></div>
 

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -6,6 +6,42 @@ description: "Comparing syntax and patterns between Unison and Java"
 
 [[toc]]
 
+# Comments
+
+<div class="side-by-side"><div>
+
+Unison comments are **not saved as a part of the function**, so they can be used as temporary notes while working, however, they will not be saved to the codebase as a part of the function definition.
+
+```unison
+-- This is a single-line comment
+
+{- This is a multi-line comment
+   spanning multiple lines -}
+```
+
+If you want to leave a note to your future self or others, use a string literal instead:
+
+```unison
+aFunction =
+  _ = "This is a magic number, don't change it"
+  42 + 1
+```
+
+</div><div>
+
+Java uses `//` for single-line comments and `/* ... */` for multi-line comments. Java code is saved to the file system, so comments are part of the codebase.
+
+```java
+// This is a single-line comment
+
+/*
+   This is a multi-line comment
+   spanning multiple lines
+*/
+```
+
+</div></div>
+
 # Variables and basic expressions
 
 <div class="side-by-side"><div>
@@ -73,7 +109,6 @@ Since Java 10, local variables can use `var` for type inference, but the method 
 
 </div></div>
 
-
 ### Access modifiers
 
 <div class="side-by-side"><div>
@@ -109,7 +144,7 @@ public String publicValue = "Accessible from anywhere";
 
 <div class="side-by-side"><div>
 
-There are no interfaces for collections in Unison. Our standard library provides a variety of distinct collection types, like `List`, `Set`, and `Map`, and more specialized collections like `NonEmptyList` and `NatMap`.
+There are no interfaces for collections in Unison. Our standard library provides a variety of distinct collection types, like `List`, `Set`, and `Map`.
 
 ```unison
 aList : List Nat
@@ -136,7 +171,7 @@ Set<String> aSet = Set.of("🍎", "🍌", "🍒");
 Map<String, Integer> aMap = Map.of("📘", 2, "📙", -4, "📔", 3);
 ```
 
-Java collections are **mutable** by default, but you can create immutable collections using factory methods like these from the `List`, `Set`, and `Map` interfaces.
+Java collections are **mutable** by default, but you can create immutable collections using factory methods from the `List`, `Set`, and `Map` interfaces.
 
 </div></div>
 
@@ -144,7 +179,7 @@ Java collections are **mutable** by default, but you can create immutable collec
 
 <div class="side-by-side"><div>
 
-If you're coming from a Java background, you might be used to modifying collections in place. In Unison, since collections are immutable, you create copies of the original with the desired changes.
+In Unison, since collections are immutable, you create copies of the original with the desired changes.
 
 ```unison
 map1 = Map.fromList [("📘", +2), ("📙", -4), ("📔", +3)]
@@ -201,8 +236,6 @@ List.foldLeft (acc n -> acc + n) 0 [1, 2, 3, 4]
 ```
 
 This style avoids explicit indexing and mutation. Iteration is __declarative__: you say what to do with each element, not how to step through the collection.
-
-
 
 </div><div>
 
@@ -417,7 +450,7 @@ greeter.getName = do
   name = readLine()
 
 greeter.greet : Text -> '{IO, Exception} ()
-greeter.greet name =
+greeter.greet name = do
   if Text.isEmpty name then
     printLine "Hello, stranger!"
   else
@@ -459,7 +492,7 @@ public class Greeter {
 }
 ```
 
-In Java programs, you create instances of classes and invoke methods on them:
+In Java programs, you create instances of classes and invoke methods on them, changing their internal state and performing actions.
 
 ```java
 public class Main {
@@ -473,3 +506,145 @@ public class Main {
 
 </div></div>
 
+# Control flow
+
+## Conditionals
+
+<div class="side-by-side"><div>
+
+In Unison, conditionals are expressions that control the flow of execution and return values. A conditional expression has three parts: the `if` condition which must be a `Boolean`, the `then` branch, and the `else` branch.
+
+```unison
+sign : Int -> Text
+sign n =
+  if n > 0 then
+    "positive"
+  else if n < 0 then
+    "negative"
+  else
+    "zero"
+```
+
+In Unison, you cannot have an `if` without an `else` branch. This will fail to compile and you cannot save it to your codebase:
+
+```unison
+nope : Nat -> Text
+nope n =
+  if n > 0 then
+    "positive"
+  -- 🚫 Will not compile, missing else branch.
+```
+
+</div><div>
+
+In Java, conditionals are statements that control the flow of execution. The `if` statement has a condition followed by a block of code, `{}`, for the "then" branch, and optionally an `else` branch.
+
+```java
+String sign(int n) {
+    if (n > 0) {
+        return "positive";
+    } else if (n < 0) {
+        return "negative";
+    } else {
+        return "zero";
+    }
+}
+```
+
+In Java, you can have an `if` statement without an `else` branch:
+
+```java
+String maybePositive(int n) {
+    if (n > 0) {
+        return "positive";
+    }
+    return "not positive";
+}
+```
+
+</div></div>
+
+## Switch statements and pattern matching
+
+<div class="side-by-side"><div>
+
+In Unison, **pattern matching** directs the flow of execution by branching on the shape and/or content of a value, without nesting or chaining multiple if/else conditions.
+
+```unison
+cardSuit : Nat -> Text
+cardSuit n =
+  match n with
+    1 -> "Hearts"
+    2 -> "Diamonds"
+    3 -> "Clubs"
+    4 -> "Spades"
+    _ -> "Invalid suit"
+```
+
+The `_` wildcard pattern matches any value not matched by previous patterns. A `match` _expression must be exhaustive_, meaning all possible inputs must be handled.
+
+</div><div>
+
+Java **switch statements** provide a way to execute different branches of code based on a value. However, they are less flexible than Unison's pattern matching.
+
+```java
+String cardSuit(int n) {
+    switch (n) {
+        case 1:
+            return "Hearts";
+        case 2:
+            return "Diamonds";
+        case 3:
+            return "Clubs";
+        case 4:
+            return "Spades";
+        default:
+            return "Invalid suit";
+    }
+}
+```
+
+`default` is slightly different from Unison's `_` wildcard pattern, as a switch statement which does not contain explicit `return` statements or `break` statements will run the `default` case.
+
+Switch statements _do not need to be exhaustive_, so if a value does not match any case and there is no `default`, the program simply continues after the switch block.
+
+</div></div>
+
+### Pattern guards
+
+<div class="side-by-side"><div>
+
+In Unison, pattern matching can include guards, which are additional boolean conditions following `|` in the pattern that must be satisfied for a pattern to match.
+
+```unison
+grade : Nat -> Text
+grade score =
+  match score with
+    s | s >= 90 -> "A"
+    s | s >= 80 -> "B"
+    s | s >= 70 -> "C"
+    s | s >= 60 -> "D"
+    _ -> "F"
+```
+
+</div><div>
+
+Java switch statements do not support guards. You would need to use if/else statements for similar functionality.
+
+```java
+String grade(int score) {
+    if (score >= 90) {
+        return "A";
+    } else if (score >= 80) {
+        return "B";
+    } else if (score >= 70) {
+        return "C";
+    } else if (score >= 60) {
+        return "D";
+    } else {
+        return "F";
+    }
+}
+```
+
+</div></div>

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -309,7 +309,8 @@ Since Java 8, collections also support lambdas and streams, which bring them clo
 <div class="side-by-side"><div>
 
 ```unison
-List.takeWhile(n -> n < 4) [1, 2, 3, 4, 5] -- Take numbers until we see a 4
+-- Take numbers until we see a 4
+List.takeWhile(n -> n < 4) [1, 2, 3, 4, 5]
   |> List.filter(n -> not (n % 2 === 0)) -- Only keep odd numbers
 -- [1, 3]
 ```
@@ -439,7 +440,7 @@ Many of the methods in the `Optional` class are similar to those in Unison's `Op
 
 <div class="side-by-side"><div>
 
-In Unison, **delayed computations** are used to represent computations that are not executed until their result is needed. Think of delayed computations as zero argument functions, `() -> r`. In type signatures, they are represented with the syntactic sugar `'r`.
+In Unison, **delayed computations** are used to represent computations that are not executed until their result is needed. Think of delayed computations as zero argument functions, `() -> t`. In type signatures, they are represented with the syntactic sugar `'t`.
 
 ```unison
 delayedVal : 'Nat

--- a/src/compare-lang/unison-for-java-devs.md
+++ b/src/compare-lang/unison-for-java-devs.md
@@ -304,6 +304,39 @@ Since Java 8, collections also support lambdas and streams, which bring them clo
 
 </div></div>
 
+#### Break and continue
+
+<div class="side-by-side"><div>
+
+```unison
+List.takeWhile(n -> n < 4) [1, 2, 3, 4, 5]
+  |> List.filter(n -> not (n % 2 === 0))
+-- [1, 3]
+```
+
+In Unison, short-circuiting constructs like `break` and `continue` do not exist. Instead, functions like `List.takeWhile` express similar behaviors. Breaking out of loops is more generally handled through recursion or by using Unison abilities like `Throw` or `Abort` for more complex control flow.
+
+</div><div>
+
+```java
+for (int n : numbers) {
+    if (n > 4) {
+        break; // Exit the loop early
+    }
+    if (n % 2 == 0) {
+        continue; // Skip even numbers
+    }
+    System.out.println(n);
+    // Output: 1, 3
+}
+```
+
+Java also provides the `break` and `continue` keywords to control loop flow, which have no direct equivalent in Unison.
+
+
+
+</div></div>
+
 ### Lambdas
 
 <div class="side-by-side"><div>
@@ -598,7 +631,7 @@ public class Main {
 
 </div></div>
 
-### Import statements
+## Import statements
 
 <div class="side-by-side"><div>
 


### PR DESCRIPTION
This adds a Java language comparison for Unison. We wanted to ensure that a C-family language was also reflected in these guides. 

Notes: 
* I've confirmed the Java code examples compile/are runnable. However, most code examples are given outside of a class definition, for brevity. 
* Someone on the team may have more current Java and OOP wisdom. (Java 8 crew, hey!) But perfection is the enemy of the good, and the good is the enemy of the done. 
* A subsequent website deployment will link this to the sidebar.

The side-by-side presentation looks like this: 
<img width="1127" height="628" alt="Screenshot 2025-09-17 at 2 43 20 PM" src="https://github.com/user-attachments/assets/309c315a-831b-41ac-9aab-fa92e8fa492a" />
